### PR TITLE
Add some convenience methods for working with SetOperation

### DIFF
--- a/src/main/java/com/yahoo/sketches/hll/Fields.java
+++ b/src/main/java/com/yahoo/sketches/hll/Fields.java
@@ -11,9 +11,9 @@ package com.yahoo.sketches.hll;
  */
 public interface Fields
 {
-  public static byte NAIVE_DENSE_VERSION = 0x0;
-  public static byte HASH_SPARSE_VERSION = 0x1;
-  public static byte SORTED_SPARSE_VERSION = 0x2;
+  byte NAIVE_DENSE_VERSION = 0x0;
+  byte HASH_SPARSE_VERSION = 0x1;
+  byte SORTED_SPARSE_VERSION = 0x2;
 
   Preamble getPreamble();
 
@@ -54,7 +54,7 @@ public interface Fields
 
   BucketIterator getBucketIterator();
 
-  public static interface UpdateCallback {
+  interface UpdateCallback {
     void bucketUpdated(int bucket, byte oldVal, byte newVal);
   }
 }

--- a/src/main/java/com/yahoo/sketches/hll/Preamble.java
+++ b/src/main/java/com/yahoo/sketches/hll/Preamble.java
@@ -15,7 +15,7 @@ public class Preamble
   public static final byte DEFAULT_PREAMBLE_FAMILY_ID = 6;
   public static final byte PERAMBLE_SIZE_BYTES = 8;
 
-  public static final int[] AUX_SIZE = new int[] {
+  public static final int[] AUX_SIZE = new int[]{
       1, 4, 4, 4, 4, 4, 4, 8, 8, 8,
       16, 16, 32, 32, 64, 128, 256, 512, 1024, 2048,
       4096, 8192, 16384, 32768, 65536, 131072, 262144
@@ -29,7 +29,8 @@ public class Preamble
   private byte flags;
   private short seedHash;
 
-  public Preamble(byte preambleSize, byte version, byte familyId, byte logConfigK, byte flags, short seedHash) {
+  public Preamble(byte preambleSize, byte version, byte familyId, byte logConfigK, byte flags, short seedHash)
+  {
     this.preambleSize = preambleSize;
     this.version = version;
     this.familyId = familyId;
@@ -47,15 +48,16 @@ public class Preamble
     }
   }
 
-  public static Preamble fromMemory(Memory memory) {
+  public static Preamble fromMemory(Memory memory)
+  {
     Builder builder = new Builder()
         .setPreambleSize(memory.getByte(0))
         .setVersion(memory.getByte(1))
         .setFamilyId(memory.getByte(2))
         .setLogConfigK(memory.getByte(3))
-        // Invert the ++ in order to skip over the unused byte.  A bunch of bits are wasted
-        // instead of packing the preamble so that the semantics of the various parts of the
-        // preamble can be aligned across different sketches.
+            // Invert the ++ in order to skip over the unused byte.  A bunch of bits are wasted
+            // instead of packing the preamble so that the semantics of the various parts of the
+            // preamble can be aligned across different sketches.
         .setFlags(memory.getByte(5));
 
     short seedHash = memory.getShort(6);
@@ -68,21 +70,25 @@ public class Preamble
    * versions that did not have this concept.
    *
    * @param seed the given seed.
+   *
    * @return the seed hash.
    */
-  private static short computeSeedHash(long seed) {
+  private static short computeSeedHash(long seed)
+  {
     long[] seedArr = {seed};
     short seedHash = (short) ((MurmurHash3.hash(seedArr, 0L)[0]) & 0xFFFFL);
     if (seedHash == 0) {
       throw new IllegalArgumentException(
           "The given seed: " + seed + " produced a seedHash of zero. " +
-              "You must choose a different seed.");
+          "You must choose a different seed."
+      );
     }
     return seedHash;
   }
 
 
-  public static Preamble createSharedPreamble(int logConfigK) {
+  public static Preamble createSharedPreamble(int logConfigK)
+  {
     if (logConfigK > 255) {
       throw new IllegalArgumentException("logConfigK is greater than a byte, make it smaller");
     }
@@ -98,22 +104,23 @@ public class Preamble
         .build();
 
     short seedHash = computeSeedHash(Util.DEFAULT_UPDATE_SEED);
-    Preamble preamble = new Builder()
+
+    return new Builder()
         .setLogConfigK((byte) logConfigK)
         .setFlags(flags)
         .setSeedHash(seedHash)
         .build();
-
-    return preamble;
   }
 
-  public byte[] toByteArray() {
+  public byte[] toByteArray()
+  {
     byte[] retVal = new byte[getPreambleSize() << 3];
     intoByteArray(retVal, 0);
     return retVal;
   }
 
-  public int intoByteArray(byte[] bytes, int offset) {
+  public int intoByteArray(byte[] bytes, int offset)
+  {
     if (bytes.length - offset < 8) {
       throw new IllegalArgumentException("bytes too small");
     }
@@ -128,58 +135,84 @@ public class Preamble
     return offset + 8;
   }
 
-  public byte getPreambleSize() {
+  public byte getPreambleSize()
+  {
     return preambleSize;
   }
 
-  public byte getVersion() {
+  public byte getVersion()
+  {
     return version;
   }
 
-  public byte getFamilyId() {
+  public byte getFamilyId()
+  {
     return familyId;
   }
 
-  public byte getLogConfigK() {
+  public byte getLogConfigK()
+  {
     return logConfigK;
   }
 
-  public int getConfigK() {
+  public int getConfigK()
+  {
     return 1 << logConfigK;
   }
 
-  public int getMaxAuxSize() {
+  public int getMaxAuxSize()
+  {
     return AUX_SIZE[logConfigK] << 2;
   }
 
-  public byte getFlags() {
+  public byte getFlags()
+  {
     return flags;
   }
 
-  public short getSeedHash() {
+  public short getSeedHash()
+  {
     return seedHash;
   }
 
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+  public boolean equals(Object o)
+  {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
 
     Preamble preamble = (Preamble) o;
 
-    if (familyId != preamble.familyId) return false;
-    if (flags != preamble.flags) return false;
-    if (logConfigK != preamble.logConfigK) return false;
-    if (preambleSize != preamble.preambleSize) return false;
-    if (seedHash != preamble.seedHash) return false;
-    if (version != preamble.version) return false;
+    if (familyId != preamble.familyId) {
+      return false;
+    }
+    if (flags != preamble.flags) {
+      return false;
+    }
+    if (logConfigK != preamble.logConfigK) {
+      return false;
+    }
+    if (preambleSize != preamble.preambleSize) {
+      return false;
+    }
+    if (seedHash != preamble.seedHash) {
+      return false;
+    }
+    if (version != preamble.version) {
+      return false;
+    }
 
     return true;
   }
 
   @SuppressWarnings("cast")
   @Override
-  public int hashCode() {
+  public int hashCode()
+  {
     int result = (int) preambleSize;
     result = 31 * result + (int) version;
     result = 31 * result + (int) familyId;
@@ -189,7 +222,8 @@ public class Preamble
     return result;
   }
 
-  public static class Builder {
+  public static class Builder
+  {
     private byte preambleSize = Preamble.DEFAULT_PREAMBLE_SIZE;
     private byte version = Preamble.DEFAULT_PREAMBLE_VERSION;
     private byte familyId = Preamble.DEFAULT_PREAMBLE_FAMILY_ID;
@@ -197,37 +231,44 @@ public class Preamble
     private byte flags;
     private short seedHash;
 
-    public Builder setPreambleSize(byte preambleSize) {
+    public Builder setPreambleSize(byte preambleSize)
+    {
       this.preambleSize = preambleSize;
       return this;
     }
 
-    public Builder setVersion(byte version) {
+    public Builder setVersion(byte version)
+    {
       this.version = version;
       return this;
     }
 
-    public Builder setFamilyId(byte familyId) {
+    public Builder setFamilyId(byte familyId)
+    {
       this.familyId = familyId;
       return this;
     }
 
-    public Builder setLogConfigK(byte logConfigK) {
+    public Builder setLogConfigK(byte logConfigK)
+    {
       this.logConfigK = logConfigK;
       return this;
     }
 
-    public Builder setFlags(byte flags) {
+    public Builder setFlags(byte flags)
+    {
       this.flags = flags;
       return this;
     }
 
-    public Builder setSeedHash(short seedHash) {
+    public Builder setSeedHash(short seedHash)
+    {
       this.seedHash = seedHash;
       return this;
     }
 
-    public Preamble build() {
+    public Preamble build()
+    {
       return new Preamble(preambleSize, version, familyId, logConfigK, flags, seedHash);
     }
 

--- a/src/main/java/com/yahoo/sketches/theta/SetOperation.java
+++ b/src/main/java/com/yahoo/sketches/theta/SetOperation.java
@@ -105,7 +105,7 @@ public class SetOperation {
      * Returns a configured SetOperation with the given
      * <a href="{@docRoot}/resources/dictionary.html#defaultNomEntries">Default Nominal Entries</a>
      * @param family the chosen SetOperation family
-     * @return an UpdateSketch
+     * @return an SetOperation
      */
     public SetOperation build(Family family) {
       return build(DEFAULT_NOMINAL_ENTRIES, family);
@@ -154,6 +154,63 @@ public class SetOperation {
               "Given Family cannot be built as a SetOperation: "+family.toString());
       }
       return setOp;
+    }
+
+    /**
+     * Convenience method, returns a configured SetOperation Union with
+     * <a href="{@docRoot}/resources/dictionary.html#defaultNomEntries">Default Nominal Entries</a>
+     * @return a Union object
+     */
+    public Union buildUnion() {
+      return (Union) build(Family.UNION);
+    }
+
+    /**
+     * Convenience method, returns a configured SetOperation Union with the given
+     * <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entries</a>.
+     * @param nomEntries <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entres</a>
+     * @return a Union object
+     */
+    public Union buildUnion(int nomEntries) {
+      return (Union) build(nomEntries, Family.UNION);
+    }
+
+    /**
+     * Convenience method, returns a configured SetOperation Intersection with
+     * <a href="{@docRoot}/resources/dictionary.html#defaultNomEntries">Default Nominal Entries</a>
+     * @return a Intersection object
+     */
+    public Intersection buildIntersection() {
+      return (Intersection) build(Family.INTERSECTION);
+    }
+
+    /**
+     * Convenience method, returns a configured SetOperation Intersection with the given
+     * <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entries</a>.
+     * @param nomEntries <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entres</a>
+     * @return a Intersection object
+     */
+    public Intersection buildIntersection(int nomEntries) {
+      return (Intersection) build(nomEntries, Family.INTERSECTION);
+    }
+
+    /**
+     * Convenience method, returns a configured SetOperation ANotB with
+     * <a href="{@docRoot}/resources/dictionary.html#defaultNomEntries">Default Nominal Entries</a>
+     * @return a ANotB object
+     */
+    public AnotB buildANotB() {
+      return (AnotB) build(Family.A_NOT_B);
+    }
+
+    /**
+     * Convenience method, returns a configured SetOperation ANotB with the given
+     * <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entries</a>.
+     * @param nomEntries <a href="{@docRoot}/resources/dictionary.html#nomEntries">Nominal Entres</a>
+     * @return a ANotB object
+     */
+    public AnotB buildANotB(int nomEntries) {
+      return (AnotB) build(nomEntries, Family.A_NOT_B);
     }
   }
   

--- a/src/main/java/com/yahoo/sketches/theta/Sketches.java
+++ b/src/main/java/com/yahoo/sketches/theta/Sketches.java
@@ -93,7 +93,29 @@ public class Sketches {
   public static SetOperation wrapSetOperation(Memory srcMem) {
     return SetOperation.wrap(srcMem);
   }
-  
+
+  /**
+   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Union
+   * @param srcMem an image of a Union
+   * @return a Union backed by the given Memory
+   * @throws IllegalArgumentException if given image does not match a known
+   * SetOperation implementation, or if the assumed default seed does not match the image seed hash.
+   */
+  public static Union wrapUnion(Memory srcMem) {
+    return (Union) SetOperation.wrap(srcMem);
+  }
+
+  /**
+   * Convenience method, calls {@link SetOperation#wrap(Memory)} and casts the result to a Intersection
+   * @param srcMem an image of a Intersection
+   * @return a Intersection backed by the given Memory
+   * @throws IllegalArgumentException if given image does not match a known
+   * SetOperation implementation, or if the assumed default seed does not match the image seed hash.
+   */
+  public static Intersection wrapIntersection(Memory srcMem) {
+    return (Intersection) SetOperation.wrap(srcMem);
+  }
+
   /**
    * Ref: {@link SetOperation#wrap(Memory, long) SetOperation.wrap(Memory, long)}
    * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
@@ -147,5 +169,4 @@ public class Sketches {
   public static int getMaxIntersectionBytes(int nomEntries) {
     return SetOperation.getMaxIntersectionBytes(nomEntries);
   }
-  
 }

--- a/src/test/java/com/yahoo/sketches/FamilyTest.java
+++ b/src/test/java/com/yahoo/sketches/FamilyTest.java
@@ -60,13 +60,13 @@ public class FamilyTest {
   @SuppressWarnings("unused")
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBadFamilyName() {
-    Family fam = stringToFamily("Test");
+    stringToFamily("Test");
   }
   
   @SuppressWarnings("unused")
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBadObject() {
-    Family fam = objectToFamily("Test");
+    objectToFamily("Test");
   }
   
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/src/test/java/com/yahoo/sketches/benchmark/SketchBenchmark.java
+++ b/src/test/java/com/yahoo/sketches/benchmark/SketchBenchmark.java
@@ -6,11 +6,11 @@ import java.util.List;
  */
 public interface SketchBenchmark
 {
-  public void setup(int numSketches, List<Spec> specs);
-  public void runNTimes(int n);
-  public void reset();
+  void setup(int numSketches, List<Spec> specs);
+  void runNTimes(int n);
+  void reset();
 
-  public class Spec {
+  class Spec {
     private final int numSketches;
     private final long numEntries;
 

--- a/src/test/java/com/yahoo/sketches/benchmark/ThetaBenchmark.java
+++ b/src/test/java/com/yahoo/sketches/benchmark/ThetaBenchmark.java
@@ -1,6 +1,5 @@
 package com.yahoo.sketches.benchmark;
 
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.theta.CompactSketch;
 import com.yahoo.sketches.theta.SetOperation;
 import com.yahoo.sketches.theta.Sketch;

--- a/src/test/java/com/yahoo/sketches/benchmark/ThetaBenchmark.java
+++ b/src/test/java/com/yahoo/sketches/benchmark/ThetaBenchmark.java
@@ -61,7 +61,7 @@ public class ThetaBenchmark implements SketchBenchmark
   public void runNTimes(int n)
   {
     for (int i = 0; i < n; ++i) {
-      Union combined = (Union) SetOperation.builder().build(nominalEntries, Family.UNION);
+      Union combined = SetOperation.builder().buildUnion(nominalEntries);
       for (Object toUnion : sketches) {
         combined.update((Sketch) toUnion);
       }

--- a/src/test/java/com/yahoo/sketches/benchmark/ThetaMemoryBenchmark.java
+++ b/src/test/java/com/yahoo/sketches/benchmark/ThetaMemoryBenchmark.java
@@ -64,10 +64,7 @@ public class ThetaMemoryBenchmark implements SketchBenchmark
   public void runNTimes(int n)
   {
     for (int i = 0; i < n; ++i) {
-      Union combined = (Union) SetOperation
-          .builder()
-          .setMemory(new NativeMemory(bytes))
-          .build(nominalEntries, Family.UNION);
+      Union combined = SetOperation.builder().setMemory(new NativeMemory(bytes)).buildUnion(nominalEntries);
       for (Memory toUnion : memories) {
         combined.update(toUnion);
       }

--- a/src/test/java/com/yahoo/sketches/benchmark/ThetaMemoryBenchmark.java
+++ b/src/test/java/com/yahoo/sketches/benchmark/ThetaMemoryBenchmark.java
@@ -1,6 +1,5 @@
 package com.yahoo.sketches.benchmark;
 
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.NativeMemory;
 import com.yahoo.sketches.theta.SetOperation;

--- a/src/test/java/com/yahoo/sketches/theta/DirectIntersectionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/DirectIntersectionTest.java
@@ -16,12 +16,6 @@ import org.testng.annotations.Test;
 import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.NativeMemory;
-import com.yahoo.sketches.theta.CompactSketch;
-import com.yahoo.sketches.theta.DirectIntersection;
-import com.yahoo.sketches.theta.Intersection;
-import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Union;
-import com.yahoo.sketches.theta.UpdateSketch;
 
 /**
  * @author Lee Rhodes
@@ -44,7 +38,7 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
 
     inter.update(usk1);
     inter.update(usk2);
@@ -87,7 +81,7 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(usk1);
     inter.update(usk2);
     
@@ -132,8 +126,8 @@ public class DirectIntersectionTest {
     CompactSketch csk1 = usk1.compact(true, null);
     CompactSketch csk2 = usk2.compact(true, null);
     
-    Intersection inter = 
-        (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    Intersection inter =
+        SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(csk1);
     inter.update(csk2);
     
@@ -153,7 +147,7 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     assertFalse(inter.hasResult());
     CompactSketch rsk1 = inter.getResult(false, null);
   }
@@ -172,7 +166,7 @@ public class DirectIntersectionTest {
     Memory iMem = new NativeMemory(memArr);
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(null);  
     rsk1 = inter.getResult(false, null);
     est = rsk1.getEstimate();
@@ -181,7 +175,7 @@ public class DirectIntersectionTest {
     
     //1st call = empty
     sk = UpdateSketch.builder().build(k); //empty
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk);
     rsk1 = inter.getResult(false, null);
     est = rsk1.getEstimate();
@@ -191,7 +185,7 @@ public class DirectIntersectionTest {
     //1st call = valid and not empty
     sk = UpdateSketch.builder().build(k);
     sk.update(1);
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk);
     rsk1 = inter.getResult(false, null);
     est = rsk1.getEstimate();
@@ -213,7 +207,7 @@ public class DirectIntersectionTest {
     Memory iMem = new NativeMemory(memArr);
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(null);
     //2nd call = null
     inter.update(null);
@@ -223,7 +217,7 @@ public class DirectIntersectionTest {
     println("Est: "+est);
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(null);
     //2nd call = empty
     sk = UpdateSketch.builder().build(); //empty
@@ -234,7 +228,7 @@ public class DirectIntersectionTest {
     println("Est: "+est);
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(null);
     //2nd call = valid & not empty
     sk = UpdateSketch.builder().build(); 
@@ -261,7 +255,7 @@ public class DirectIntersectionTest {
     
     //1st call = empty
     sk1 = UpdateSketch.builder().build(); //empty
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = null
     inter.update(null);
@@ -272,7 +266,7 @@ public class DirectIntersectionTest {
     
     //1st call = empty
     sk1 = UpdateSketch.builder().build(); //empty
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = empty
     sk2 = UpdateSketch.builder().build(); //empty
@@ -284,7 +278,7 @@ public class DirectIntersectionTest {
     
     //1st call = empty
     sk1 = UpdateSketch.builder().build(); //empty
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = valid and not empty
     sk2 = UpdateSketch.builder().build();
@@ -312,7 +306,7 @@ public class DirectIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = null
     inter.update(null);
@@ -324,7 +318,7 @@ public class DirectIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = empty
     sk2 = UpdateSketch.builder().build(); //empty
@@ -337,7 +331,7 @@ public class DirectIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = valid intersecting
     sk2 = UpdateSketch.builder().build(); //empty
@@ -351,7 +345,7 @@ public class DirectIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     //2nd call = valid not intersecting
     sk2 = UpdateSketch.builder().build(); //empty
@@ -381,7 +375,7 @@ public class DirectIntersectionTest {
     for (int i=0; i<2*k; i++) sk1.update(i);  //est mode
     println("sk1: "+sk1.getEstimate());
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     
     //2nd call = valid intersecting
@@ -416,7 +410,7 @@ public class DirectIntersectionTest {
     println("sk1est: "+sk1.getEstimate());
     println("sk1cnt: "+sk1.getRetainedEntries(true));
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
   }
   
@@ -438,7 +432,7 @@ public class DirectIntersectionTest {
     for (int i=0; i<2*k; i++) sk1.update(i);  //est mode
     println("sk1: "+sk1.getEstimate());
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(sk1);
     
     //2nd call = valid intersecting
@@ -470,14 +464,14 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter1 = (Intersection) SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION); //virgin
-    inter2 = (Intersection) SetOperation.wrap(iMem);
+    inter1 = SetOperation.builder().setMemory(iMem).buildIntersection(k); //virgin
+    inter2 = Sketches.wrapIntersection(iMem);
     //both in virgin state, empty = false
     assertFalse(inter1.hasResult());
     assertFalse(inter2.hasResult());
     
     inter1.update(null);  //A virgin intersection intersected with null => empty = true;
-    inter2 = (Intersection) SetOperation.wrap(iMem);
+    inter2 = Sketches.wrapIntersection(iMem);
     assertTrue(inter1.hasResult());
     assertTrue(inter2.hasResult());
     CompactSketch comp = inter2.getResult(true, null);
@@ -496,8 +490,8 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter1 = (Intersection) SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION); //virgin
-    inter2 = (Intersection) SetOperation.wrap(iMem);
+    inter1 = SetOperation.builder().setMemory(iMem).buildIntersection(k); //virgin
+    inter2 = Sketches.wrapIntersection(iMem);
     //both in virgin state, empty = false
     assertFalse(inter1.hasResult());
     assertFalse(inter2.hasResult());
@@ -508,7 +502,7 @@ public class DirectIntersectionTest {
     //remains empty = false.
     
     inter1.update(sk1);
-    inter2 = (Intersection) SetOperation.wrap(iMem);
+    inter2 = Sketches.wrapIntersection(iMem);
     assertTrue(inter1.hasResult());
     assertTrue(inter2.hasResult());
     CompactSketch comp = inter2.getResult(true, null);
@@ -525,7 +519,7 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    Intersection inter = (Intersection) SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
   }
   
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -547,7 +541,7 @@ public class DirectIntersectionTest {
     CompactSketch csk1 = usk1.compact(true, null);
     CompactSketch csk2 = usk2.compact(true, null);
     
-    Intersection inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k/2, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().setMemory(iMem).buildIntersection(k / 2);
     inter.update(csk1);
     inter.update(csk2);
   }
@@ -562,12 +556,12 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter1 = (Intersection) SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION); //virgin
+    inter1 = SetOperation.builder().setMemory(iMem).buildIntersection(k); //virgin
     byte[] byteArray = inter1.toByteArray();
     Memory mem = new NativeMemory(byteArray);
     //corrupt:
     mem.putByte(PREAMBLE_LONGS_BYTE, (byte) 2);//RF not used = 0
-    inter2 = (Intersection) SetOperation.wrap(mem);
+    inter2 = Sketches.wrapIntersection(mem);
   }
   
   @SuppressWarnings("unused")
@@ -580,12 +574,12 @@ public class DirectIntersectionTest {
     byte[] memArr = new byte[memBytes];
     Memory iMem = new NativeMemory(memArr);
     
-    inter1 = (Intersection) SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION); //virgin
+    inter1 = SetOperation.builder().setMemory(iMem).buildIntersection(k); //virgin
     byte[] byteArray = inter1.toByteArray();
     Memory mem = new NativeMemory(byteArray);
     //corrupt:
     mem.putByte(SER_VER_BYTE, (byte) 2);
-    inter2 = (Intersection) SetOperation.wrap(mem); //throws in SetOperations
+    inter2 = Sketches.wrapIntersection(mem); //throws in SetOperations
   }
   
   @SuppressWarnings("unused")
@@ -595,10 +589,10 @@ public class DirectIntersectionTest {
     Union union;
     Intersection inter1;
     
-    union = (Union) SetOperation.builder().build(k, Family.UNION);
+    union = SetOperation.builder().buildUnion(k);
     byte[] byteArray = union.toByteArray();
     Memory mem = new NativeMemory(byteArray);
-    inter1 = (Intersection) SetOperation.wrap(mem);
+    inter1 = Sketches.wrapIntersection(mem);
   }
   
   @Test
@@ -620,12 +614,12 @@ public class DirectIntersectionTest {
     CompactSketch compSkIn1 = sk1.compact(true, null);
     println("compSkIn1: "+compSkIn1.getEstimate());
     
-    inter = (Intersection)SetOperation.builder().setMemory(iMem).build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().setMemory(iMem).buildIntersection(k);
     inter.update(compSkIn1);
     
     byte[] memArr2 = inter.toByteArray();
     Memory srcMem = new NativeMemory(memArr2);
-    inter2 = (Intersection) SetOperation.wrap(srcMem);
+    inter2 = Sketches.wrapIntersection(srcMem);
     
     //2nd call = valid intersecting
     sk2 = UpdateSketch.builder().build(k);
@@ -641,7 +635,7 @@ public class DirectIntersectionTest {
     
     byte[] memArr3 = inter2.toByteArray();
     Memory srcMem2 = new NativeMemory(memArr3);
-    inter3 = (Intersection) SetOperation.wrap(srcMem2);
+    inter3 = Sketches.wrapIntersection(srcMem2);
     resultComp2 = inter3.getResult(false, null);
     est2 = resultComp2.getEstimate();
     println("Est2: "+est2);

--- a/src/test/java/com/yahoo/sketches/theta/DirectUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/DirectUnionTest.java
@@ -16,11 +16,6 @@ import org.testng.annotations.Test;
 import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.NativeMemory;
-import com.yahoo.sketches.theta.CompactSketch;
-import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Sketch;
-import com.yahoo.sketches.theta.Union;
-import com.yahoo.sketches.theta.UpdateSketch;
 
 /**
  * @author Lee Rhodes
@@ -42,7 +37,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -63,7 +58,7 @@ public class DirectUnionTest {
     for (int i=u/2; i<u; i++) usk2.update(i); //2*k no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -86,7 +81,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate()/2, 0.0); //exact, overlapped
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -109,7 +104,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -137,14 +132,14 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
     
     testAllCompactForms(union, u, 0.0);
     
-    Union union2 = (Union)SetOperation.wrap(new NativeMemory(union.toByteArray()));
+    Union union2 = Sketches.wrapUnion(new NativeMemory(union.toByteArray()));
     
     testAllCompactForms(union2, u, 0.0);
   }
@@ -162,14 +157,14 @@ public class DirectUnionTest {
     for (int i=u/2; i<u; i++) usk2.update(i); //2k no overlap, exact
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch, early stop not possible
     
     testAllCompactForms(union, u, 0.05);
     
-    Union union2 = (Union)SetOperation.wrap(new NativeMemory(union.toByteArray()));
+    Union union2 = Sketches.wrapUnion(new NativeMemory(union.toByteArray()));
     
     testAllCompactForms(union2, u, 0.05);
   }
@@ -189,7 +184,7 @@ public class DirectUnionTest {
     CompactSketch cosk2 = usk2.compact(true, null);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);  //update with heap UpdateSketch
     union.update(cosk2); //update with heap Compact, Ordered input, early stop
@@ -201,7 +196,7 @@ public class DirectUnionTest {
     
     testAllCompactForms(union, u, 0.05);
     
-    Union union2 = (Union)SetOperation.wrap(new NativeMemory(union.toByteArray()));
+    Union union2 = Sketches.wrapUnion(new NativeMemory(union.toByteArray()));
     
     testAllCompactForms(union2, u, 0.05);
     
@@ -225,7 +220,7 @@ public class DirectUnionTest {
     CompactSketch cosk2 = usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);      //updates with heap UpdateSketch
     union.update(cosk2);     //updates with direct CompactSketch, ordered, use early stop
@@ -237,7 +232,7 @@ public class DirectUnionTest {
     
     testAllCompactForms(union, u, 0.05);
     
-    Union union2 = (Union)SetOperation.wrap(new NativeMemory(union.toByteArray()));
+    Union union2 = Sketches.wrapUnion(new NativeMemory(union.toByteArray()));
     
     testAllCompactForms(union2, u, 0.05);
     
@@ -261,7 +256,7 @@ public class DirectUnionTest {
     usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -273,7 +268,7 @@ public class DirectUnionTest {
     
     testAllCompactForms(union, u, 0.05);
     
-    Union union2 = (Union)SetOperation.wrap(new NativeMemory(union.toByteArray()));
+    Union union2 = Sketches.wrapUnion(new NativeMemory(union.toByteArray()));
     
     testAllCompactForms(union2, u, 0.05);
     
@@ -297,7 +292,7 @@ public class DirectUnionTest {
     usk2.compact(false, cskMem2); //unordered, loads the cskMem2 as unordered
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -309,7 +304,7 @@ public class DirectUnionTest {
     
     testAllCompactForms(union, u, 0.05);
     
-    Union union2 = (Union)SetOperation.wrap(new NativeMemory(union.toByteArray()));
+    Union union2 = Sketches.wrapUnion(new NativeMemory(union.toByteArray()));
     
     testAllCompactForms(union2, u, 0.05);
     
@@ -340,7 +335,7 @@ public class DirectUnionTest {
     v += u;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //updates with heap UpdateSketch
     union.update(usk2); //updates with heap UpdateSketch
@@ -373,7 +368,7 @@ public class DirectUnionTest {
     CompactSketch csk2 = (CompactSketch)Sketch.wrap(skMem2);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(csk1);
     union.update(csk2);
@@ -403,7 +398,7 @@ public class DirectUnionTest {
     Memory v1mem2 = convertSerV3toSerV1(skMem2);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(v1mem1);
     union.update(v1mem2);
@@ -433,7 +428,7 @@ public class DirectUnionTest {
     Memory v2mem2 = convertSerV3toSerV2(skMem2);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(v2mem1);
     union.update(v2mem2);
@@ -454,7 +449,7 @@ public class DirectUnionTest {
     Memory v1mem1 = convertSerV3toSerV1(v3mem1);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(v1mem1);
     CompactSketch cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
@@ -462,19 +457,19 @@ public class DirectUnionTest {
     Memory v2mem1 = convertSerV3toSerV2(v3mem1);
     
     uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(v2mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
     uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(v3mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
     uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     v3mem1 = null;
     union.update(v3mem1);
     cOut = union.getResult(true, null);
@@ -486,7 +481,7 @@ public class DirectUnionTest {
   public void checkDirectWrap() {
     int nomEntries = 16;
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(nomEntries)]);
-    SetOperation.builder().setMemory(uMem).build(nomEntries, Family.UNION);
+    SetOperation.builder().setMemory(uMem).buildUnion(nomEntries);
     
     UpdateSketch sk1 = UpdateSketch.builder().build(nomEntries);
     sk1.update("a");
@@ -496,10 +491,10 @@ public class DirectUnionTest {
     sk2.update("c");
     sk2.update("d");
     
-    Union union = (Union) SetOperation.wrap(uMem);
+    Union union = Sketches.wrapUnion(uMem);
     union.update(sk1);
     
-    union = (Union) SetOperation.wrap(uMem);
+    union = Sketches.wrapUnion(uMem);
     union.update(sk2);
     
     CompactSketch sketch = union.getResult(true, null);
@@ -511,7 +506,7 @@ public class DirectUnionTest {
     int k = 64;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     Memory mem = new NativeMemory(new byte[Sketch.getMaxCompactSketchBytes(0)]);
     CompactSketch csk = union.getResult(false, mem); //DirectCompactSketch
@@ -523,7 +518,7 @@ public class DirectUnionTest {
     int k = 64;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     Memory mem = new NativeMemory(new byte[Sketch.getMaxCompactSketchBytes(0)]);
     CompactSketch csk = union.getResult(true, mem); //DirectCompactSketch
@@ -535,7 +530,7 @@ public class DirectUnionTest {
     int k = 64;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    SetOperation.builder().setMemory(uMem).buildUnion(k);
 
     //println(PreambleUtil.toString(uMem));
   }

--- a/src/test/java/com/yahoo/sketches/theta/DirectUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/DirectUnionTest.java
@@ -4,18 +4,16 @@
  */
 package com.yahoo.sketches.theta;
 
-import static com.yahoo.sketches.theta.ForwardCompatibilityTest.convertSerV3toSerV1;
-import static com.yahoo.sketches.theta.ForwardCompatibilityTest.convertSerV3toSerV2;
-import static com.yahoo.sketches.theta.HeapUnionTest.*;
-import static com.yahoo.sketches.theta.SetOperation.*;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import org.testng.annotations.Test;
-
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.NativeMemory;
+import org.testng.annotations.Test;
+
+import static com.yahoo.sketches.theta.ForwardCompatibilityTest.convertSerV3toSerV1;
+import static com.yahoo.sketches.theta.ForwardCompatibilityTest.convertSerV3toSerV2;
+import static com.yahoo.sketches.theta.HeapUnionTest.testAllCompactForms;
+import static com.yahoo.sketches.theta.SetOperation.getMaxUnionBytes;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Lee Rhodes
@@ -37,7 +35,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -58,7 +56,7 @@ public class DirectUnionTest {
     for (int i=u/2; i<u; i++) usk2.update(i); //2*k no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -81,7 +79,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate()/2, 0.0); //exact, overlapped
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -104,7 +102,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -132,7 +130,7 @@ public class DirectUnionTest {
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -157,7 +155,7 @@ public class DirectUnionTest {
     for (int i=u/2; i<u; i++) usk2.update(i); //2k no overlap, exact
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch, early stop not possible
@@ -184,7 +182,7 @@ public class DirectUnionTest {
     CompactSketch cosk2 = usk2.compact(true, null);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);  //update with heap UpdateSketch
     union.update(cosk2); //update with heap Compact, Ordered input, early stop
@@ -220,7 +218,7 @@ public class DirectUnionTest {
     CompactSketch cosk2 = usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);      //updates with heap UpdateSketch
     union.update(cosk2);     //updates with direct CompactSketch, ordered, use early stop
@@ -256,7 +254,7 @@ public class DirectUnionTest {
     usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -292,7 +290,7 @@ public class DirectUnionTest {
     usk2.compact(false, cskMem2); //unordered, loads the cskMem2 as unordered
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -335,7 +333,7 @@ public class DirectUnionTest {
     v += u;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(usk1); //updates with heap UpdateSketch
     union.update(usk2); //updates with heap UpdateSketch
@@ -368,7 +366,7 @@ public class DirectUnionTest {
     CompactSketch csk2 = (CompactSketch)Sketch.wrap(skMem2);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(csk1);
     union.update(csk2);
@@ -398,7 +396,7 @@ public class DirectUnionTest {
     Memory v1mem2 = convertSerV3toSerV1(skMem2);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(v1mem1);
     union.update(v1mem2);
@@ -428,7 +426,7 @@ public class DirectUnionTest {
     Memory v2mem2 = convertSerV3toSerV2(skMem2);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     union.update(v2mem1);
     union.update(v2mem2);
@@ -449,7 +447,7 @@ public class DirectUnionTest {
     Memory v1mem1 = convertSerV3toSerV1(v3mem1);
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(v1mem1);
     CompactSketch cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
@@ -457,19 +455,19 @@ public class DirectUnionTest {
     Memory v2mem1 = convertSerV3toSerV2(v3mem1);
     
     uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(v2mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
     uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(v3mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
     uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     v3mem1 = null;
     union.update(v3mem1);
     cOut = union.getResult(true, null);
@@ -506,7 +504,7 @@ public class DirectUnionTest {
     int k = 64;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     Memory mem = new NativeMemory(new byte[Sketch.getMaxCompactSketchBytes(0)]);
     CompactSketch csk = union.getResult(false, mem); //DirectCompactSketch
@@ -518,7 +516,7 @@ public class DirectUnionTest {
     int k = 64;
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]); //union memory
-    Union union = (Union)SetOperation.builder().setMemory(uMem).buildUnion(k);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     
     Memory mem = new NativeMemory(new byte[Sketch.getMaxCompactSketchBytes(0)]);
     CompactSketch csk = union.getResult(true, mem); //DirectCompactSketch

--- a/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
@@ -4,20 +4,13 @@
  */
 package com.yahoo.sketches.theta;
 
+import com.yahoo.sketches.memory.Memory;
+import com.yahoo.sketches.memory.NativeMemory;
+import org.testng.annotations.Test;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-
-import org.testng.annotations.Test;
-
-import com.yahoo.sketches.Family;
-import com.yahoo.sketches.memory.Memory;
-import com.yahoo.sketches.memory.NativeMemory;
-import com.yahoo.sketches.theta.AnotB;
-import com.yahoo.sketches.theta.CompactSketch;
-import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Sketch;
-import com.yahoo.sketches.theta.UpdateSketch;
 
 /**
  * @author Lee Rhodes

--- a/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
@@ -34,7 +34,7 @@ public class HeapAnotBTest {
     for (int i=0; i<k/2; i++) usk1.update(i);
     for (int i=k/2; i<k; i++) usk2.update(i);
     
-    AnotB aNb = (AnotB)SetOperation.builder().build(Family.A_NOT_B);
+    AnotB aNb = SetOperation.builder().buildANotB();
     aNb.update(usk1, usk2);
     
     CompactSketch rsk1;
@@ -82,7 +82,7 @@ public class HeapAnotBTest {
     AnotB aNb;
     boolean ordered = true;
     
-    aNb = (AnotB)SetOperation.builder().build(Family.A_NOT_B);
+    aNb = SetOperation.builder().buildANotB();
 
     aNb.update(aNull, bNull);
     res = aNb.getResult(!ordered, null);
@@ -261,7 +261,7 @@ public class HeapAnotBTest {
     Memory mem1 = new NativeMemory(memArr1);
     Memory mem2 = new NativeMemory(memArr2);
     
-    AnotB aNb = (AnotB) SetOperation.builder().build(Family.A_NOT_B);
+    AnotB aNb = SetOperation.builder().buildANotB();
     aNb.update(aU, bU);
     r1 = aNb.getResult(ordered, mem1);
     
@@ -292,7 +292,7 @@ public class HeapAnotBTest {
     Memory mem = new NativeMemory(memArr);
     
     CompactSketch r;
-    AnotB aNb = (AnotB) SetOperation.builder().build(Family.A_NOT_B);
+    AnotB aNb = SetOperation.builder().buildANotB();
     
     //Iterative loop: {
     aNb.update(a, b);

--- a/src/test/java/com/yahoo/sketches/theta/HeapIntersectionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapIntersectionTest.java
@@ -43,7 +43,7 @@ public class HeapIntersectionTest {
     for (int i=0; i<k/2; i++) usk1.update(i);
     for (int i=k/2; i<k; i++) usk2.update(i);
     
-    Intersection inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().buildIntersection(k);
 
     inter.update(usk1);
     inter.update(usk2);
@@ -81,7 +81,7 @@ public class HeapIntersectionTest {
     for (int i=0; i<k; i++) usk1.update(i);
     for (int i=0; i<k; i++) usk2.update(i);
     
-    Intersection inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().buildIntersection(k);
     inter.update(usk1);
     inter.update(usk2);
     
@@ -121,7 +121,7 @@ public class HeapIntersectionTest {
     CompactSketch csk1 = usk1.compact(true, null);
     CompactSketch csk2 = usk2.compact(true, null);
     
-    Intersection inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().buildIntersection(k);
     inter.update(csk1);
     inter.update(csk2);
     
@@ -135,7 +135,7 @@ public class HeapIntersectionTest {
   public void checkNoCall() {
     int lgK = 9;
     int k = 1<<lgK;
-    Intersection inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().buildIntersection(k);
     assertFalse(inter.hasResult());
     CompactSketch rsk1 = inter.getResult(false, null);
   }
@@ -150,7 +150,7 @@ public class HeapIntersectionTest {
     double est;
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(null);  
     rsk1 = inter.getResult(false, null);
     est = rsk1.getEstimate();
@@ -159,7 +159,7 @@ public class HeapIntersectionTest {
     
     //1st call = empty
     sk = UpdateSketch.builder().build(k); //empty
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk);
     rsk1 = inter.getResult(false, null);
     est = rsk1.getEstimate();
@@ -169,7 +169,7 @@ public class HeapIntersectionTest {
     //1st call = valid and not empty
     sk = UpdateSketch.builder().build(k);
     sk.update(1);
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk);
     rsk1 = inter.getResult(false, null);
     est = rsk1.getEstimate();
@@ -187,7 +187,7 @@ public class HeapIntersectionTest {
     double est;
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(null);
     //2nd call = null
     inter.update(null);
@@ -197,7 +197,7 @@ public class HeapIntersectionTest {
     println("Est: "+est);
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(null);
     //2nd call = empty
     sk = UpdateSketch.builder().build(); //empty
@@ -208,7 +208,7 @@ public class HeapIntersectionTest {
     println("Est: "+est);
     
     //1st call = null
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(null);
     //2nd call = valid & not empty
     sk = UpdateSketch.builder().build(); 
@@ -231,7 +231,7 @@ public class HeapIntersectionTest {
     
     //1st call = empty
     sk1 = UpdateSketch.builder().build(); //empty
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = null
     inter.update(null);
@@ -242,7 +242,7 @@ public class HeapIntersectionTest {
     
     //1st call = empty
     sk1 = UpdateSketch.builder().build(); //empty
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = empty
     sk2 = UpdateSketch.builder().build(); //empty
@@ -254,7 +254,7 @@ public class HeapIntersectionTest {
     
     //1st call = empty
     sk1 = UpdateSketch.builder().build(); //empty
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = valid and not empty
     sk2 = UpdateSketch.builder().build();
@@ -278,7 +278,7 @@ public class HeapIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = null
     inter.update(null);
@@ -290,7 +290,7 @@ public class HeapIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = empty
     sk2 = UpdateSketch.builder().build(); //empty
@@ -303,7 +303,7 @@ public class HeapIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = valid intersecting
     sk2 = UpdateSketch.builder().build(); //empty
@@ -317,7 +317,7 @@ public class HeapIntersectionTest {
     //1st call = valid
     sk1 = UpdateSketch.builder().build();
     sk1.update(1);
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION); 
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     //2nd call = valid not intersecting
     sk2 = UpdateSketch.builder().build(); //empty
@@ -343,7 +343,7 @@ public class HeapIntersectionTest {
     for (int i=0; i<2*k; i++) sk1.update(i);  //est mode
     println("sk1: "+sk1.getEstimate());
     
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(sk1);
     
     //2nd call = valid intersecting
@@ -374,7 +374,7 @@ public class HeapIntersectionTest {
     println("sk1est: "+sk1.getEstimate());
     println("sk1cnt: "+sk1.getRetainedEntries(true));
     
-    inter = (Intersection)SetOperation.builder().build(k, Family.INTERSECTION); //Too small
+    inter = SetOperation.builder().buildIntersection(k); //Too small
     inter.update(sk1);
   }
   
@@ -393,7 +393,7 @@ public class HeapIntersectionTest {
     println("compSkIn1: "+compSkIn1.getEstimate());
     
     //1st call = valid
-    inter = (Intersection) SetOperation.builder().build(k, Family.INTERSECTION);
+    inter = SetOperation.builder().buildIntersection(k);
     inter.update(compSkIn1);
     
     //2nd call = valid intersecting
@@ -426,7 +426,7 @@ public class HeapIntersectionTest {
     int k = 1<<lgK;
     Intersection inter1, inter2;
     
-    inter1 = (Intersection) SetOperation.builder().build(k, Family.INTERSECTION); //virgin
+    inter1 = SetOperation.builder().buildIntersection(k); //virgin
     byte[] byteArray = inter1.toByteArray();
     Memory srcMem = new NativeMemory(byteArray);
     inter2 = (Intersection) SetOperation.heapify(srcMem);
@@ -449,7 +449,7 @@ public class HeapIntersectionTest {
     Intersection inter1, inter2;
     UpdateSketch sk1;
     
-    inter1 = (Intersection) SetOperation.builder().build(k, Family.INTERSECTION); //virgin
+    inter1 = SetOperation.builder().buildIntersection(k); //virgin
     byte[] byteArray = inter1.toByteArray();
     Memory srcMem = new NativeMemory(byteArray);
     inter2 = (Intersection) SetOperation.heapify(srcMem);
@@ -473,7 +473,7 @@ public class HeapIntersectionTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkSizeLowerLimit() {
     int k = 8;
-    Intersection inter = (Intersection) SetOperation.builder().build(k, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().buildIntersection(k);
   }
   
   @SuppressWarnings("unused")
@@ -492,7 +492,7 @@ public class HeapIntersectionTest {
     CompactSketch csk1 = usk1.compact(true, null);
     CompactSketch csk2 = usk2.compact(true, null);
     
-    Intersection inter = (Intersection)SetOperation.builder().build(k/2, Family.INTERSECTION);
+    Intersection inter = SetOperation.builder().buildIntersection(k / 2);
     inter.update(csk1);
     inter.update(csk2);
   }
@@ -503,7 +503,7 @@ public class HeapIntersectionTest {
     int k = 32;
     Intersection inter1, inter2;
     
-    inter1 = (Intersection) SetOperation.builder().build(k, Family.INTERSECTION); //virgin
+    inter1 = SetOperation.builder().buildIntersection(k); //virgin
     byte[] byteArray = inter1.toByteArray();
     Memory mem = new NativeMemory(byteArray);
     //corrupt:
@@ -517,7 +517,7 @@ public class HeapIntersectionTest {
     int k = 32;
     Intersection inter1, inter2;
     
-    inter1 = (Intersection) SetOperation.builder().build(k, Family.INTERSECTION); //virgin
+    inter1 = SetOperation.builder().buildIntersection(k); //virgin
     byte[] byteArray = inter1.toByteArray();
     Memory mem = new NativeMemory(byteArray);
     //corrupt:
@@ -532,7 +532,7 @@ public class HeapIntersectionTest {
     Union union;
     Intersection inter1;
     
-    union = (Union) SetOperation.builder().build(k, Family.UNION);
+    union = SetOperation.builder().buildUnion(k);
     byte[] byteArray = union.toByteArray();
     Memory mem = new NativeMemory(byteArray);
     inter1 = (Intersection) SetOperation.heapify(mem);

--- a/src/test/java/com/yahoo/sketches/theta/HeapUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapUnionTest.java
@@ -36,7 +36,7 @@ public class HeapUnionTest {
     
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -56,7 +56,7 @@ public class HeapUnionTest {
     for (int i=0; i<u/2; i++) usk1.update(i); //2*k
     for (int i=u/2; i<u; i++) usk2.update(i); //2*k no overlap
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -78,7 +78,7 @@ public class HeapUnionTest {
     
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate()/2, 0.0); //exact, overlapped
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -100,7 +100,7 @@ public class HeapUnionTest {
     
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -124,7 +124,7 @@ public class HeapUnionTest {
     for (int i=0; i<u/2; i++) usk1.update(i); //2k
     for (int i=u/2; i<u; i++) usk2.update(i); //2k no overlap, exact
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch, early stop not possible
@@ -150,7 +150,7 @@ public class HeapUnionTest {
     
     CompactSketch cosk2 = usk2.compact(true, null);
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1);  //update with heap UpdateSketch
     union.update(cosk2); //update with heap Compact, Ordered input, early stop
@@ -185,7 +185,7 @@ public class HeapUnionTest {
     NativeMemory cskMem2 = new NativeMemory(new byte[usk2.getCurrentBytes(true)]);
     CompactSketch cosk2 = usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cosk2);       //updates with direct CompactSketch, ordered, use early stop
@@ -220,7 +220,7 @@ public class HeapUnionTest {
     NativeMemory cskMem2 = new NativeMemory(new byte[usk2.getCurrentBytes(true)]);
     usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -255,7 +255,7 @@ public class HeapUnionTest {
     NativeMemory cskMem2 = new NativeMemory(new byte[usk2.getCurrentBytes(true)]);
     usk2.compact(false, cskMem2); //unordered, loads the cskMem2 as unordered
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -297,7 +297,7 @@ public class HeapUnionTest {
     for (int i=0; i<u; i++) usk4.update(i+v);
     v += u;
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //updates with heap UpdateSketch
     union.update(usk2); //updates with heap UpdateSketch
@@ -329,7 +329,7 @@ public class HeapUnionTest {
     CompactSketch csk1 = (CompactSketch)Sketch.wrap(skMem1);
     CompactSketch csk2 = (CompactSketch)Sketch.wrap(skMem2);
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(csk1);
     union.update(csk2);
@@ -358,7 +358,7 @@ public class HeapUnionTest {
     Memory v1mem1 = convertSerV3toSerV1(skMem1);
     Memory v1mem2 = convertSerV3toSerV1(skMem2);
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(v1mem1);
     union.update(v1mem2);
@@ -387,7 +387,7 @@ public class HeapUnionTest {
     Memory v2mem1 = convertSerV3toSerV2(skMem1);
     Memory v2mem2 = convertSerV3toSerV2(skMem2);
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     
     union.update(v2mem1);
     union.update(v2mem2);
@@ -407,24 +407,24 @@ public class HeapUnionTest {
     
     Memory v1mem1 = convertSerV3toSerV1(v3mem1);
     
-    Union union = (Union)SetOperation.builder().build(k, Family.UNION);
+    Union union = (Union)SetOperation.builder().buildUnion(k);
     union.update(v1mem1);
     CompactSketch cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
     Memory v2mem1 = convertSerV3toSerV2(v3mem1);
     
-    union = (Union)SetOperation.builder().build(k, Family.UNION);
+    union = (Union)SetOperation.builder().buildUnion(k);
     union.update(v2mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
-    union = (Union)SetOperation.builder().build(k, Family.UNION);
+    union = (Union)SetOperation.builder().buildUnion(k);
     union.update(v3mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
-    union = (Union)SetOperation.builder().build(k, Family.UNION);
+    union = (Union)SetOperation.builder().buildUnion(k);
     v3mem1 = null;
     union.update(v3mem1);
     cOut = union.getResult(true, null);

--- a/src/test/java/com/yahoo/sketches/theta/HeapUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapUnionTest.java
@@ -4,18 +4,13 @@
  */
 package com.yahoo.sketches.theta;
 
-import static com.yahoo.sketches.theta.ForwardCompatibilityTest.*;
-import static org.testng.Assert.assertEquals;
-
-import org.testng.annotations.Test;
-
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.NativeMemory;
-import com.yahoo.sketches.theta.CompactSketch;
-import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Union;
-import com.yahoo.sketches.theta.UpdateSketch;
+import org.testng.annotations.Test;
+
+import static com.yahoo.sketches.theta.ForwardCompatibilityTest.convertSerV3toSerV1;
+import static com.yahoo.sketches.theta.ForwardCompatibilityTest.convertSerV3toSerV2;
+import static org.testng.Assert.assertEquals;
 
 /**
  * @author Lee Rhodes
@@ -36,7 +31,7 @@ public class HeapUnionTest {
     
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -56,7 +51,7 @@ public class HeapUnionTest {
     for (int i=0; i<u/2; i++) usk1.update(i); //2*k
     for (int i=u/2; i<u; i++) usk2.update(i); //2*k no overlap
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -78,7 +73,7 @@ public class HeapUnionTest {
     
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate()/2, 0.0); //exact, overlapped
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -100,7 +95,7 @@ public class HeapUnionTest {
     
     assertEquals(u, usk1.getEstimate() + usk2.getEstimate(), 0.0); //exact, no overlap
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch
@@ -124,7 +119,7 @@ public class HeapUnionTest {
     for (int i=0; i<u/2; i++) usk1.update(i); //2k
     for (int i=u/2; i<u; i++) usk2.update(i); //2k no overlap, exact
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //update with heap UpdateSketch
     union.update(usk2); //update with heap UpdateSketch, early stop not possible
@@ -150,7 +145,7 @@ public class HeapUnionTest {
     
     CompactSketch cosk2 = usk2.compact(true, null);
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1);  //update with heap UpdateSketch
     union.update(cosk2); //update with heap Compact, Ordered input, early stop
@@ -185,7 +180,7 @@ public class HeapUnionTest {
     NativeMemory cskMem2 = new NativeMemory(new byte[usk2.getCurrentBytes(true)]);
     CompactSketch cosk2 = usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cosk2);       //updates with direct CompactSketch, ordered, use early stop
@@ -220,7 +215,7 @@ public class HeapUnionTest {
     NativeMemory cskMem2 = new NativeMemory(new byte[usk2.getCurrentBytes(true)]);
     usk2.compact(true, cskMem2); //ordered, loads the cskMem2 as ordered
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -255,7 +250,7 @@ public class HeapUnionTest {
     NativeMemory cskMem2 = new NativeMemory(new byte[usk2.getCurrentBytes(true)]);
     usk2.compact(false, cskMem2); //unordered, loads the cskMem2 as unordered
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1);        //updates with heap UpdateSketch
     union.update(cskMem2);     //updates with direct CompactSketch, ordered, use early stop
@@ -297,7 +292,7 @@ public class HeapUnionTest {
     for (int i=0; i<u; i++) usk4.update(i+v);
     v += u;
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(usk1); //updates with heap UpdateSketch
     union.update(usk2); //updates with heap UpdateSketch
@@ -329,7 +324,7 @@ public class HeapUnionTest {
     CompactSketch csk1 = (CompactSketch)Sketch.wrap(skMem1);
     CompactSketch csk2 = (CompactSketch)Sketch.wrap(skMem2);
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(csk1);
     union.update(csk2);
@@ -358,7 +353,7 @@ public class HeapUnionTest {
     Memory v1mem1 = convertSerV3toSerV1(skMem1);
     Memory v1mem2 = convertSerV3toSerV1(skMem2);
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(v1mem1);
     union.update(v1mem2);
@@ -387,7 +382,7 @@ public class HeapUnionTest {
     Memory v2mem1 = convertSerV3toSerV2(skMem1);
     Memory v2mem2 = convertSerV3toSerV2(skMem2);
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     
     union.update(v2mem1);
     union.update(v2mem2);
@@ -407,24 +402,24 @@ public class HeapUnionTest {
     
     Memory v1mem1 = convertSerV3toSerV1(v3mem1);
     
-    Union union = (Union)SetOperation.builder().buildUnion(k);
+    Union union = SetOperation.builder().buildUnion(k);
     union.update(v1mem1);
     CompactSketch cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
     Memory v2mem1 = convertSerV3toSerV2(v3mem1);
     
-    union = (Union)SetOperation.builder().buildUnion(k);
+    union = SetOperation.builder().buildUnion(k);
     union.update(v2mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
-    union = (Union)SetOperation.builder().buildUnion(k);
+    union = SetOperation.builder().buildUnion(k);
     union.update(v3mem1);
     cOut = union.getResult(true, null);
     assertEquals(cOut.getEstimate(), 0.0, 0.0);
     
-    union = (Union)SetOperation.builder().buildUnion(k);
+    union = SetOperation.builder().buildUnion(k);
     v3mem1 = null;
     union.update(v3mem1);
     cOut = union.getResult(true, null);

--- a/src/test/java/com/yahoo/sketches/theta/PreambleUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/PreambleUtilTest.java
@@ -47,7 +47,7 @@ public class PreambleUtilTest {
     println(PreambleUtil.toString(mem));
     
     Memory uMem = new NativeMemory(new byte[getMaxUnionBytes(k)]);
-    Union union = (Union)SetOperation.builder().setMemory(uMem).build(k, Family.UNION);
+    Union union = SetOperation.builder().setMemory(uMem).buildUnion(k);
     union.update(quick1);
     println(PreambleUtil.toString(uMem));
     

--- a/src/test/java/com/yahoo/sketches/theta/SetOperationTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SetOperationTest.java
@@ -16,11 +16,6 @@ import com.yahoo.sketches.Family;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.MemoryRegion;
 import com.yahoo.sketches.memory.NativeMemory;
-import com.yahoo.sketches.theta.CompactSketch;
-import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Sketch;
-import com.yahoo.sketches.theta.Union;
-import com.yahoo.sketches.theta.UpdateSketch;
 
 /**
  * @author Lee Rhodes
@@ -40,7 +35,7 @@ public class SetOperationTest {
     
     ResizeFactor rf = X4;
     //use default size
-    Union union = (Union)SetOperation.builder().setSeed(seed).setResizeFactor(rf).build(Family.UNION);
+    Union union = SetOperation.builder().setSeed(seed).setResizeFactor(rf).buildUnion();
     
     union.update(usk1);
     union.update(usk2);
@@ -55,37 +50,37 @@ public class SetOperationTest {
   @SuppressWarnings("unused")
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBuilderBadK() {
-    Union union = (Union)SetOperation.builder().build(1000, Family.UNION);
+    Union union = SetOperation.builder().buildUnion(1000);
   }
   
   @SuppressWarnings("unused")
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBuilderBadFamily() {
-    Union union = (Union)SetOperation.builder().build(Family.ALPHA);
+    SetOperation.builder().build(Family.ALPHA);
   }
   
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBuilderIllegalPhi() {
     float p = (float)1.5;
-    SetOperation.builder().setP(p).build(Family.UNION);
+    SetOperation.builder().setP(p).buildUnion();
   }
   
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBuilderIllegalPlo() {
     float p = 0;
-    SetOperation.builder().setP(p).build(Family.UNION);
+    SetOperation.builder().setP(p).buildUnion();
   }
   
   @Test
   public void checkBuilderValidP() {
     float p = (float).5;
-    SetOperation.builder().setP(p).build(Family.UNION);
+    SetOperation.builder().setP(p).buildUnion();
   }
   
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkBuilderAnotB_noMem() {
     Memory mem = new NativeMemory(new byte[64]);
-    SetOperation.builder().setMemory(mem).build(Family.A_NOT_B);
+    SetOperation.builder().setMemory(mem).buildANotB();
   }
   
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -101,7 +96,7 @@ public class SetOperationTest {
     
     ResizeFactor rf = X4;
     
-    Union union = (Union)SetOperation.builder().setSeed(seed).setResizeFactor(rf).build(k, Family.UNION);
+    Union union = SetOperation.builder().setSeed(seed).setResizeFactor(rf).buildUnion(k);
     
     union.update(usk1);
     union.update(usk2); //throws seed exception here
@@ -206,8 +201,7 @@ public class SetOperationTest {
     int bytes = heapLayout[1] - offset;
     Memory unionMem = new MemoryRegion(heapMem, offset, bytes);
 
-    Union union = (Union) 
-        SetOperation.builder().setMemory(unionMem).build(unionNomEntries, Family.UNION);
+    Union union = SetOperation.builder().setMemory(unionMem).buildUnion(unionNomEntries);
 
     Memory sketch1mem = new MemoryRegion(heapMem, heapLayout[1], heapLayout[2]-heapLayout[1]);
     Memory sketch2mem = new MemoryRegion(heapMem, heapLayout[2], heapLayout[3]-heapLayout[2]);
@@ -237,7 +231,7 @@ public class SetOperationTest {
     union.update(sk2);
     
     //Let's recover the union and the 3rd sketch
-    union = (Union) SetOperation.wrap(unionMem);
+    union = Sketches.wrapUnion(unionMem);
     sk3 = (UpdateSketch) Sketch.wrap(sketch3mem);
     union.update(sk3);
     
@@ -268,8 +262,7 @@ public class SetOperationTest {
 
     //Create a new union in the same space with a smaller size.
     unionMem.clear();
-    Union union = (Union) 
-        SetOperation.builder().setMemory(unionMem).build(unionNomEntries, Family.UNION);
+    Union union = SetOperation.builder().setMemory(unionMem).buildUnion(unionNomEntries);
     union.update(sk1);
     union.update(sk2);
     union.update(sk3);

--- a/src/test/java/com/yahoo/sketches/theta/SketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchTest.java
@@ -238,7 +238,7 @@ public class SketchTest {
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void checkHeapifyFamilyExcep() {
     int k = 512;
-    Union union = (Union) SetOperation.builder().build(k, UNION);
+    Union union = SetOperation.builder().buildUnion(k);
     byte[] byteArray = union.toByteArray();
     Memory mem = new NativeMemory(byteArray);
     //Improper use

--- a/src/test/java/com/yahoo/sketches/theta/SketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchTest.java
@@ -4,30 +4,23 @@
  */
 package com.yahoo.sketches.theta;
 
+import com.yahoo.sketches.Family;
+import com.yahoo.sketches.memory.Memory;
+import com.yahoo.sketches.memory.NativeMemory;
+import org.testng.annotations.Test;
+
 import static com.yahoo.sketches.Family.ALPHA;
 import static com.yahoo.sketches.Family.QUICKSELECT;
-import static com.yahoo.sketches.Family.UNION;
 import static com.yahoo.sketches.Util.DEFAULT_NOMINAL_ENTRIES;
 import static com.yahoo.sketches.Util.DEFAULT_UPDATE_SEED;
 import static com.yahoo.sketches.theta.PreambleUtil.COMPACT_FLAG_MASK;
 import static com.yahoo.sketches.theta.PreambleUtil.FLAGS_BYTE;
-import static com.yahoo.sketches.theta.Sketch.getMaxCompactSketchBytes;
 import static com.yahoo.sketches.theta.ResizeFactor.X1;
 import static com.yahoo.sketches.theta.ResizeFactor.X2;
 import static com.yahoo.sketches.theta.ResizeFactor.X4;
 import static com.yahoo.sketches.theta.ResizeFactor.X8;
+import static com.yahoo.sketches.theta.Sketch.getMaxCompactSketchBytes;
 import static org.testng.Assert.assertEquals;
-
-import org.testng.annotations.Test;
-
-import com.yahoo.sketches.Family;
-import com.yahoo.sketches.memory.Memory;
-import com.yahoo.sketches.memory.NativeMemory;
-import com.yahoo.sketches.theta.CompactSketch;
-import com.yahoo.sketches.theta.SetOperation;
-import com.yahoo.sketches.theta.Sketch;
-import com.yahoo.sketches.theta.Union;
-import com.yahoo.sketches.theta.UpdateSketch;
 
 /**
  * @author Lee Rhodes

--- a/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
@@ -4,15 +4,23 @@
  */
 package com.yahoo.sketches.theta;
 
-import static org.testng.Assert.assertEquals;
-
-import static com.yahoo.sketches.theta.Sketches.*;
-import org.testng.annotations.Test;
-
-import com.yahoo.sketches.Family;
 import com.yahoo.sketches.Util;
 import com.yahoo.sketches.memory.Memory;
 import com.yahoo.sketches.memory.NativeMemory;
+import org.testng.annotations.Test;
+
+import static com.yahoo.sketches.theta.Sketches.getMaxCompactSketchBytes;
+import static com.yahoo.sketches.theta.Sketches.getMaxIntersectionBytes;
+import static com.yahoo.sketches.theta.Sketches.getMaxUnionBytes;
+import static com.yahoo.sketches.theta.Sketches.getMaxUpdateSketchBytes;
+import static com.yahoo.sketches.theta.Sketches.getSerializationVersion;
+import static com.yahoo.sketches.theta.Sketches.heapifySetOperation;
+import static com.yahoo.sketches.theta.Sketches.heapifySketch;
+import static com.yahoo.sketches.theta.Sketches.setOpBuilder;
+import static com.yahoo.sketches.theta.Sketches.updateSketchBuilder;
+import static com.yahoo.sketches.theta.Sketches.wrapSetOperation;
+import static com.yahoo.sketches.theta.Sketches.wrapSketch;
+import static org.testng.Assert.assertEquals;
 
 public class SketchesTest {
   

--- a/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
@@ -51,8 +51,7 @@ public class SketchesTest {
     Memory mem2 = getCompactSketch(k, k/2, 3*k/2);
     
     SetOperation.Builder bldr = setOpBuilder();
-    SetOperation setOp1 = bldr.build(2*k, Family.UNION);
-    Union union = (Union)setOp1;
+    Union union = bldr.buildUnion(2*k);
     
     union.update(mem1);
     CompactSketch cSk = union.getResult(true, null);


### PR DESCRIPTION
@leerho I've felt some weirdness with the casting after building a set operation and Mubeen did a couple of times too.  How do you feel about these convenience methods to help in those cases?

Btw, in adjusting the unit tests for this, it became clear that there aren't any unit tests for `ANotB` with a nominal entries different from the default.  Also, there doesn't appear to be any usage of `Intersection` with the default number of nominal entries.  Neither of which are particularly alarming, but potentially worth note.