### PR TITLE
replaced static lookup table for powers of 2 by fast on-demand calculation

### DIFF
--- a/src/main/java/com/yahoo/sketches/hll/HipHllSketch.java
+++ b/src/main/java/com/yahoo/sketches/hll/HipHllSketch.java
@@ -28,8 +28,8 @@ class HipHllSketch extends HllSketch
             double oneOverQ = oneOverQ();
             hipEstAccum += oneOverQ;
             // subtraction before addition is intentional, in order to avoid overflow (?)
-            invPow2Sum -= HllUtils.invPow2Table[oldVal];
-            invPow2Sum += HllUtils.invPow2Table[newVal];
+            invPow2Sum -= HllUtils.invPow2(oldVal);
+            invPow2Sum += HllUtils.invPow2(newVal);
           }
 
           private double oneOverQ()

--- a/src/main/java/com/yahoo/sketches/hll/HllUtils.java
+++ b/src/main/java/com/yahoo/sketches/hll/HllUtils.java
@@ -4,18 +4,13 @@ package com.yahoo.sketches.hll;
  */
 class HllUtils
 {
-  static double[] invPow2Table = new double[256];
-  static {
-    for (int i = 0; i < 256; i++) invPow2Table[i] = Math.pow(2.0, -1.0 * i);
-  }
-
   static double computeInvPow2Sum(int numBuckets, BucketIterator iter) {
     double retVal = 0;
     while (iter.next()) {
-      retVal += invPow2Table[iter.getValue()];
+      retVal += invPow2(iter.getValue());
       --numBuckets;
     }
-    retVal += numBuckets * invPow2Table[0];
+    retVal += numBuckets;
     return retVal;
   }
 
@@ -24,6 +19,10 @@ class HllUtils
       fields = fields.updateBucket(iter.getKey(), iter.getValue(), updateCallback);
     }
     return fields;
+  }
+
+  static double invPow2(int e) {
+      return Double.longBitsToDouble((0x3ffL - e) << 52);
   }
 
 }


### PR DESCRIPTION
This should be now as fast as the lookup table. At least I could not measure any significant difference. I naively thought that Math.scalb() (see https://github.com/DataSketches/sketches-core/pull/19) does more or less the same, but it is more than three times slower.