### PR TITLE
Remove self from @author tags

### DIFF
--- a/src/main/java/com/yahoo/sketches/hll/BucketIterator.java
+++ b/src/main/java/com/yahoo/sketches/hll/BucketIterator.java
@@ -11,7 +11,6 @@ package com.yahoo.sketches.hll;
  * getKey() and getValue().  If next() returned false, that means that iteration is complete; 
  * getKey() and getValue() become undefined.
  * 
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 public interface BucketIterator {

--- a/src/main/java/com/yahoo/sketches/hll/CompositeBucketIterator.java
+++ b/src/main/java/com/yahoo/sketches/hll/CompositeBucketIterator.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 public class CompositeBucketIterator implements BucketIterator {

--- a/src/main/java/com/yahoo/sketches/hll/CompressedBucketUtils.java
+++ b/src/main/java/com/yahoo/sketches/hll/CompressedBucketUtils.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class CompressedBucketUtils {

--- a/src/main/java/com/yahoo/sketches/hll/DenseCompressedFieldsFactory.java
+++ b/src/main/java/com/yahoo/sketches/hll/DenseCompressedFieldsFactory.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class DenseCompressedFieldsFactory implements FieldsFactory {

--- a/src/main/java/com/yahoo/sketches/hll/DenseFieldsFactory.java
+++ b/src/main/java/com/yahoo/sketches/hll/DenseFieldsFactory.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class DenseFieldsFactory implements FieldsFactory {

--- a/src/main/java/com/yahoo/sketches/hll/Fields.java
+++ b/src/main/java/com/yahoo/sketches/hll/Fields.java
@@ -13,7 +13,6 @@ package com.yahoo.sketches.hll;
  *
  * Implement at your own risk.
  * 
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 public interface Fields {

--- a/src/main/java/com/yahoo/sketches/hll/FieldsFactory.java
+++ b/src/main/java/com/yahoo/sketches/hll/FieldsFactory.java
@@ -9,7 +9,6 @@ package com.yahoo.sketches.hll;
  * They can just depend on this object to make the next Fields that they return when the sparse representation is no
  * longer considered good enough.
  *
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 interface FieldsFactory {

--- a/src/main/java/com/yahoo/sketches/hll/HarmonicNumbers.java
+++ b/src/main/java/com/yahoo/sketches/hll/HarmonicNumbers.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class HarmonicNumbers {

--- a/src/main/java/com/yahoo/sketches/hll/HashUtils.java
+++ b/src/main/java/com/yahoo/sketches/hll/HashUtils.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class HashUtils {

--- a/src/main/java/com/yahoo/sketches/hll/HipHllSketch.java
+++ b/src/main/java/com/yahoo/sketches/hll/HipHllSketch.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class HipHllSketch extends HllSketch {

--- a/src/main/java/com/yahoo/sketches/hll/HllSketch.java
+++ b/src/main/java/com/yahoo/sketches/hll/HllSketch.java
@@ -8,7 +8,6 @@ import com.yahoo.sketches.Util;
 import com.yahoo.sketches.hash.MurmurHash3;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 @SuppressWarnings("cast")

--- a/src/main/java/com/yahoo/sketches/hll/HllSketchBuilder.java
+++ b/src/main/java/com/yahoo/sketches/hll/HllSketchBuilder.java
@@ -9,7 +9,6 @@ import static com.yahoo.sketches.Util.LS;
 import static com.yahoo.sketches.Util.TAB;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 public class HllSketchBuilder { //TODO will need to add seed and Memory, etc.

--- a/src/main/java/com/yahoo/sketches/hll/HllUtils.java
+++ b/src/main/java/com/yahoo/sketches/hll/HllUtils.java
@@ -7,7 +7,6 @@ package com.yahoo.sketches.hll;
 /**
  * Utility functions for the HLL package
  * 
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class HllUtils {

--- a/src/main/java/com/yahoo/sketches/hll/Interpolation.java
+++ b/src/main/java/com/yahoo/sketches/hll/Interpolation.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class Interpolation {

--- a/src/main/java/com/yahoo/sketches/hll/OnHeapCompressedFields.java
+++ b/src/main/java/com/yahoo/sketches/hll/OnHeapCompressedFields.java
@@ -7,7 +7,6 @@ package com.yahoo.sketches.hll;
 import com.yahoo.sketches.memory.NativeMemory;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class OnHeapCompressedFields implements Fields {

--- a/src/main/java/com/yahoo/sketches/hll/OnHeapFields.java
+++ b/src/main/java/com/yahoo/sketches/hll/OnHeapFields.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class OnHeapFields implements Fields {

--- a/src/main/java/com/yahoo/sketches/hll/OnHeapHash.java
+++ b/src/main/java/com/yahoo/sketches/hll/OnHeapHash.java
@@ -10,7 +10,6 @@ import com.yahoo.sketches.memory.NativeMemory;
 import java.util.Arrays;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class OnHeapHash {

--- a/src/main/java/com/yahoo/sketches/hll/OnHeapHashFields.java
+++ b/src/main/java/com/yahoo/sketches/hll/OnHeapHashFields.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class OnHeapHashFields implements Fields {

--- a/src/main/java/com/yahoo/sketches/hll/OnHeapImmutableCompactFields.java
+++ b/src/main/java/com/yahoo/sketches/hll/OnHeapImmutableCompactFields.java
@@ -13,7 +13,6 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 class OnHeapImmutableCompactFields implements Fields {

--- a/src/main/java/com/yahoo/sketches/hll/Preamble.java
+++ b/src/main/java/com/yahoo/sketches/hll/Preamble.java
@@ -12,7 +12,6 @@ import com.yahoo.sketches.memory.MemoryRegion;
 import com.yahoo.sketches.memory.NativeMemory;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 public class Preamble {

--- a/src/main/java/com/yahoo/sketches/hll/PreambleFlags.java
+++ b/src/main/java/com/yahoo/sketches/hll/PreambleFlags.java
@@ -5,7 +5,6 @@
 package com.yahoo.sketches.hll;
 
 /**
- * @author Eric Tschetter
  * @author Kevin Lang
  */
 public class PreambleFlags {


### PR DESCRIPTION
Author tags don't provide any significant information.  Over the lifetime of a project, code lines will be changed by various different individuals, knowing the original author of a file often doesn't actually tell you anything about who is currently maintaining it or who most recently touched it.  If you want to know who to thank/blame for some lines of code, using your SCM's "blame" mechanism is the right way to get that information.