### PR TITLE
Fix bug with HIP estimation and OnHeapCompressedFields

### DIFF
--- a/src/main/java/com/yahoo/sketches/hll/OnHeapCompressedFields.java
+++ b/src/main/java/com/yahoo/sketches/hll/OnHeapCompressedFields.java
@@ -45,7 +45,7 @@ class OnHeapCompressedFields implements Fields {
           index, val, new UpdateCallback() {
             @Override
             public void bucketUpdated(int bucket, byte oldVal, byte newVal) {
-              callback.bucketUpdated(bucket, theOldVal, newVal);
+              callback.bucketUpdated(bucket, theOldVal == 0xf ? oldVal : (byte) (theOldVal + currMin), newVal);
             }
           }
       );
@@ -64,8 +64,9 @@ class OnHeapCompressedFields implements Fields {
             @Override
             public void bucketUpdated(int bucket, byte oldVal, byte newVal) {
               oldVal = (byte) (oldVal + currMin);
+              byte actualNewVal = (byte) (newVal + currMin);
               adjustNumAtCurrMin(oldVal);
-              callback.bucketUpdated(bucket, oldVal, newVal);
+              callback.bucketUpdated(bucket, oldVal, actualNewVal);
             }
           }
       );

--- a/src/test/java/com/yahoo/sketches/hll/HipHllSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/HipHllSketchTest.java
@@ -4,7 +4,8 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-public class HipHllSketchTest {
+public class HipHllSketchTest
+{
   @Test(dataProvider = "sketches")
   public void testEstimation(HllSketch sketch)
   {
@@ -18,6 +19,16 @@ public class HipHllSketchTest {
       Assert.assertTrue(sketch.getLowerBound(4.0) - 0.0001 < estimate);
       Assert.assertEquals(sketch.inversePowerOf2Sum(), inversePow2Vals[i], 0.0000001);
     }
+  }
+
+  @Test(dataProvider = "sketches")
+  public void testEstimationSanity(HllSketch sketch)
+  {
+    int numberOfUniques = 1000000;
+    for (int i = 0; i < numberOfUniques; i++) {
+      sketch.update(new int[]{i});
+    }
+    Assert.assertEquals(sketch.getEstimate(), (double) numberOfUniques, numberOfUniques * 0.01);
   }
 
   @Test
@@ -40,37 +51,39 @@ public class HipHllSketchTest {
     Assert.assertTrue(exceptionCaught, "Expected exception to be thrown");
   }
 
-    @Test
-    public void testNoUnionByte()
-    {
-        HllSketchBuilder bob = HllSketch.builder().setLogBuckets(10).setHipEstimator(true);
+  @Test
+  public void testNoUnionByte()
+  {
+    HllSketchBuilder bob = HllSketch.builder().setLogBuckets(10).setHipEstimator(true);
 
-        HllSketch sketch = bob.build();
-        sketch.update(new byte[]{18, 27, 48, 91, 27, 41, 92, 8});
+    HllSketch sketch = bob.build();
+    sketch.update(new byte[]{18, 27, 48, 91, 27, 41, 92, 8});
 
-        boolean exceptionCaught = false;
-        HllSketch unionInto = bob.build();
-        try {
-            unionInto.union(sketch);
-        }
-        catch (UnsupportedOperationException e) {
-            exceptionCaught = true;
-        }
-
-        Assert.assertTrue(exceptionCaught, "Expected exception to be thrown");
+    boolean exceptionCaught = false;
+    HllSketch unionInto = bob.build();
+    try {
+      unionInto.union(sketch);
+    }
+    catch (UnsupportedOperationException e) {
+      exceptionCaught = true;
     }
 
-    @DataProvider(name = "sketches")
+    Assert.assertTrue(exceptionCaught, "Expected exception to be thrown");
+  }
+
+  @DataProvider(name = "sketches")
   public static Object[][] getSketches()
   {
     HllSketchBuilder bob = HllSketch.builder().setLogBuckets(10).setHipEstimator(true);
     return new Object[][]{
         {bob.build()},
         {bob.copy().setDenseMode(true).build()},
+        {bob.copy().setCompressedDense(true).build()}
     };
   }
 
-  public static void main(String[] args) {
+  public static void main(String[] args)
+  {
     HllSketch sketch = (HllSketch) getSketches()[0][0];
 
     int numEntries = sketch.numBuckets();


### PR DESCRIPTION
The issue was with the logic on the values being sent back to the callbacks.  The FieldsTest unit tests weren't verifying the values on the callback, once I added that verification, the bug became apparent.

I've also added a more "functional" test to the HipHllSketchTest while also adding the OnHeapCompressedFields to the list of implementations verified.