### PR TITLE
Code quality fixes - squid:S00112, squid:S00116, squid:S00122, squid:S1213

### DIFF
--- a/src/main/java/com/yahoo/sketches/SketchesException.java
+++ b/src/main/java/com/yahoo/sketches/SketchesException.java
@@ -1,0 +1,26 @@
+package com.yahoo.sketches;
+
+/**
+ * Exception class for the library
+ */
+public class SketchesException extends RuntimeException {
+
+    public SketchesException() {
+    }
+
+    public SketchesException(String message) {
+        super(message);
+    }
+
+    public SketchesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SketchesException(Throwable cause) {
+        super(cause);
+    }
+
+    public SketchesException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00112 - Generic exceptions should never be thrown.
squid:S00116 - Field names should comply with a naming convention.
squid:S00122 - Statements should be on separate lines.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 71 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00112
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava