### PR TITLE
Code quality fix - squid:S00112, squid:S00122, squid:S1168, squid:S1213, squid:S2259

### DIFF
--- a/src/main/java/com/yahoo/sketches/SketchesException.java
+++ b/src/main/java/com/yahoo/sketches/SketchesException.java
@@ -1,0 +1,26 @@
+package com.yahoo.sketches;
+
+/**
+ * Exception class for the library
+ */
+public class SketchesException extends RuntimeException {
+
+    public SketchesException() {
+    }
+
+    public SketchesException(String message) {
+        super(message);
+    }
+
+    public SketchesException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SketchesException(Throwable cause) {
+        super(cause);
+    }
+
+    public SketchesException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00112 - Generic exceptions should never be thrown.
squid:S00122 - Statements should be on separate lines.
squid:S1168 - Empty arrays and collections should be returned instead of null.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S2259 - Null pointers should not be dereferenced.
This pull request removes 91 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00112
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1168
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
George Kankava