### PR TITLE
fixed jar with shaded memory

### DIFF
--- a/sketches/pom.xml
+++ b/sketches/pom.xml
@@ -38,16 +38,12 @@
                         <configuration>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.yahoo.sketches</pattern>
-                                    <shadedPattern>shaded.com.yahoo.sketches</shadedPattern>
-                                </relocation>
-                                <relocation>
                                     <pattern>com.yahoo.memory</pattern>
                                     <shadedPattern>shaded.com.yahoo.memory</shadedPattern>
                                 </relocation>
                             </relocations>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>with-shaded-core</shadedClassifierName>
+                            <shadedClassifierName>with-shaded-memory</shadedClassifierName>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
It seems to me that the intention was to have the sketches-core jar with shaded (included and relocated) memory