### PR TITLE
NativeMemory: Respect arrayOffset for onheap ByteBuffers.

### DIFF
--- a/memory/src/main/java/com/yahoo/memory/NativeMemory.java
+++ b/memory/src/main/java/com/yahoo/memory/NativeMemory.java
@@ -120,7 +120,7 @@ public class NativeMemory implements Memory {
       nativeRawStartAddress_ = ((sun.nio.ch.DirectBuffer)byteBuf).address();
     }
     else { //must have array
-      objectBaseOffset_ = ARRAY_BYTE_BASE_OFFSET;
+      objectBaseOffset_ = ARRAY_BYTE_BASE_OFFSET + byteBuf.arrayOffset() * ARRAY_BYTE_INDEX_SCALE;
       memArray_ = byteBuf.array();
       nativeRawStartAddress_ = 0L;
     }

--- a/memory/src/test/java/com/yahoo/memory/NativeMemoryTest.java
+++ b/memory/src/test/java/com/yahoo/memory/NativeMemoryTest.java
@@ -17,6 +17,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 import org.testng.annotations.Test;
 
@@ -565,6 +566,42 @@ public class NativeMemoryTest {
     finally {
       mem.freeMemory();
     }
+  }
+
+  @Test
+  public void testSliceDirectByteBuffer()
+  {
+    ByteBuffer buf = ByteBuffer.allocateDirect(8);
+    buf.duplicate().order(ByteOrder.nativeOrder()).putInt(1).putInt(2);
+
+    ByteBuffer buf2 = buf.duplicate();
+    buf2.position(4).limit(8);
+    buf2 = buf2.slice().order(ByteOrder.nativeOrder());
+
+    assertEquals(4, buf2.capacity());
+    assertEquals(2, buf2.getInt(0));
+
+    final NativeMemory nm = new NativeMemory(buf2.slice());
+    assertEquals(4, nm.getCapacity());
+    assertEquals(2, nm.getInt(0));
+  }
+
+  @Test
+  public void testSliceHeapByteBuffer()
+  {
+    ByteBuffer buf = ByteBuffer.allocate(8);
+    buf.duplicate().order(ByteOrder.nativeOrder()).putInt(1).putInt(2);
+
+    ByteBuffer buf2 = buf.duplicate();
+    buf2.position(4).limit(8);
+    buf2 = buf2.slice().order(ByteOrder.nativeOrder());
+
+    assertEquals(4, buf2.capacity());
+    assertEquals(2, buf2.getInt(0));
+
+    final NativeMemory nm = new NativeMemory(buf2.slice());
+    assertEquals(4, nm.getCapacity());
+    assertEquals(2, nm.getInt(0));
   }
 
   private static class DummyMemReq implements MemoryRequest {


### PR DESCRIPTION
Previously, the test `testSliceHeapByteBuffer` would fail by returning 1 instead of 2. `testSliceDirectByteBuffer` passed even before this patch, but is offered for completeness.