### PR TITLE
Introduce cleaner to clean AllocMemory and MemoryMappedFile

### DIFF
--- a/memory/src/main/java/com/yahoo/memory/AllocMemory.java
+++ b/memory/src/main/java/com/yahoo/memory/AllocMemory.java
@@ -6,6 +6,7 @@
 package com.yahoo.memory;
 
 import static com.yahoo.memory.UnsafeUtil.unsafe;
+import sun.misc.Cleaner;
 
 /**
  * The AllocMemory class is a subclass of MemoryMappedFile, which is a subclass of
@@ -22,7 +23,8 @@ import static com.yahoo.memory.UnsafeUtil.unsafe;
  * @author Lee Rhodes
  */
 //@SuppressWarnings("restriction")
-public class AllocMemory extends MemoryMappedFile {
+public class AllocMemory extends NativeMemory {
+  private final Cleaner cleaner;
 
   /**
    * Constructor to allocate native memory.
@@ -33,10 +35,7 @@ public class AllocMemory extends MemoryMappedFile {
    * @param capacityBytes the size in bytes of the native memory
    */
   public AllocMemory(final long capacityBytes) {
-    super(0L, null, null);
-    super.nativeRawStartAddress_ = unsafe.allocateMemory(capacityBytes);
-    super.capacityBytes_ = capacityBytes;
-    super.memReq_ = null;
+    this(capacityBytes, null);
   }
 
   /**
@@ -53,6 +52,8 @@ public class AllocMemory extends MemoryMappedFile {
     super.nativeRawStartAddress_ = unsafe.allocateMemory(capacityBytes);
     super.capacityBytes_ = capacityBytes;
     super.memReq_ = memReq;
+
+    cleaner = Cleaner.create(this, new Deallocator(nativeRawStartAddress_));
   }
 
   /**
@@ -61,7 +62,7 @@ public class AllocMemory extends MemoryMappedFile {
    * <p>Reallocates the given off-heap NativeMemory to a new a new native (off-heap) memory
    * location and copies the contents of the original given NativeMemory to the new location.
    * Any memory beyond the capacity of the original given NativeMemory will be uninitialized.
-   * Dispose of this new memory by calling {@link NativeMemory#freeMemory()}.
+   * Dispose of this new memory by calling {@link AllocMemory#freeMemory()}.
    * The new allocated memory will be 8-byte aligned, but may not be page aligned.
    * @param origMem The original NativeMemory that needs to be reallocated and must not be null.
    * The OS is free to just expand the capacity of the current allocation at the same native
@@ -74,13 +75,7 @@ public class AllocMemory extends MemoryMappedFile {
    */
   public AllocMemory(final NativeMemory origMem, final long newCapacityBytes,
       final MemoryRequest memReq) {
-    super(0L, null, null);
-    super.nativeRawStartAddress_ = unsafe.reallocateMemory(origMem.nativeRawStartAddress_,
-        newCapacityBytes);
-    super.capacityBytes_ = newCapacityBytes;
-    this.memReq_ = memReq;
-    origMem.nativeRawStartAddress_ = 0; //does not require freeMem
-    origMem.capacityBytes_ = 0; //Cannot be used again
+    this(origMem, origMem.getCapacity(), newCapacityBytes, memReq);
   }
 
   /**
@@ -101,10 +96,7 @@ public class AllocMemory extends MemoryMappedFile {
    */
   public AllocMemory(final NativeMemory origMem, final long copyToBytes, final long capacityBytes,
       final MemoryRequest memReq) {
-    super(0L, null, null);
-    super.nativeRawStartAddress_ = unsafe.allocateMemory(capacityBytes);
-    super.capacityBytes_ = capacityBytes;
-    this.memReq_ = memReq;
+    this(capacityBytes, memReq);
     NativeMemory.copy(origMem, 0, this, 0, copyToBytes);
     this.clear(copyToBytes, capacityBytes - copyToBytes);
   }
@@ -112,6 +104,27 @@ public class AllocMemory extends MemoryMappedFile {
   @Override
   public void freeMemory() {
     super.freeMemory();
+    cleaner.clean();
+    nativeRawStartAddress_ = 0L;
   }
 
+  private static final class Deallocator
+      implements Runnable
+  {
+    private long nativeRawStartAddress_;
+
+    private Deallocator(final long nativeRawStartAddress) {
+      assert (nativeRawStartAddress != 0);
+      this.nativeRawStartAddress_ = nativeRawStartAddress;
+    }
+
+    public void run() {
+      if (nativeRawStartAddress_ == 0) {
+        // Paranoia
+        return;
+      }
+
+      unsafe.freeMemory(nativeRawStartAddress_);
+    }
+  }
 }

--- a/memory/src/main/java/com/yahoo/memory/MemoryMappedFile.java
+++ b/memory/src/main/java/com/yahoo/memory/MemoryMappedFile.java
@@ -16,6 +16,7 @@ import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 
+import sun.misc.Cleaner;
 import sun.nio.ch.FileChannelImpl;
 
 /**
@@ -30,6 +31,7 @@ public class MemoryMappedFile extends NativeMemory {
   private FileChannel fileChannel_ = null;
   private RandomAccessFile randomAccessFile_ = null;
   private MappedByteBuffer dummyMbbInstance_ = null;
+  private final Cleaner cleaner;
 
   /**
    * Constructor for memory mapping a file.
@@ -67,11 +69,8 @@ public class MemoryMappedFile extends NativeMemory {
     // len can be more than the file.length
     randomAccessFile_.setLength(len);
     createDummyMbbInstance();
-  }
 
-  // pass-through
-  MemoryMappedFile(final long objectBaseOffset, final Object memArray, final ByteBuffer byteBuf) {
-    super(objectBaseOffset, memArray, byteBuf);
+    this.cleaner = Cleaner.create(this, new Deallocator(randomAccessFile_, nativeRawStartAddress_, capacityBytes_));
   }
 
   /**
@@ -162,46 +161,12 @@ public class MemoryMappedFile extends NativeMemory {
 
   @Override
   public void freeMemory() {
-    if (fileChannel_ != null) {
-      unmap();
-      nativeRawStartAddress_ = 0L;
-    }
     super.freeMemory();
-  }
-
-  /**
-   * If the JVM calls this method and a "freeMemory() has not been called" a <i>System.err</i>
-   * message will be logged.
-   */
-  @Override
-  protected void finalize() {
-    if (requiresFree()) {
-      System.err.println("ERROR: freeMemory() has not been called: Address: "
-          + nativeRawStartAddress_ + ", capacity: " + capacityBytes_);
-      final StackTraceElement[] arr = Thread.currentThread().getStackTrace();
-      for (int i = 0; i < arr.length; i++) {
-        System.err.println(arr[i].toString());
-      }
-    }
+    cleaner.clean();
+    nativeRawStartAddress_ = 0L;
   }
 
   // Restricted methods
-
-  /**
-   * Removes existing mapping
-   */
-  private void unmap() throws RuntimeException {
-    try {
-      final Method method = FileChannelImpl.class.getDeclaredMethod("unmap0", long.class, long.class);
-      method.setAccessible(true);
-      method.invoke(fileChannel_, nativeRawStartAddress_, capacityBytes_);
-      randomAccessFile_.close();
-    } catch (final Exception e) {
-      throw new RuntimeException(
-          String.format("Encountered %s exception while freeing memory", e.getClass()));
-    }
-  }
-
   static final int pageCount(final int ps, final long length) {
     return (int) ( (length == 0) ? 0 : (length - 1L) / ps + 1L);
   }
@@ -253,6 +218,49 @@ public class MemoryMappedFile extends NativeMemory {
     } catch (final Exception e) {
       throw new RuntimeException(
           String.format("Encountered %s exception while mapping", e.getClass()));
+    }
+  }
+
+  private static final class Deallocator
+      implements Runnable
+  {
+    private RandomAccessFile randomAccessFile_;
+    private FileChannel fileChannel_;
+    private long nativeRawStartAddress_;
+    private long capacityBytes_;
+
+    private Deallocator(final RandomAccessFile randomAccessFile,
+        final long nativeRawStartAddress, final long capacityBytes) {
+      assert (randomAccessFile != null);
+      assert (nativeRawStartAddress != 0);
+      assert (capacityBytes != 0);
+      this.randomAccessFile_ = randomAccessFile;
+      this.fileChannel_ = randomAccessFile.getChannel();
+      this.nativeRawStartAddress_ = nativeRawStartAddress;
+      this.capacityBytes_ = capacityBytes;
+    }
+
+    /**
+     * Removes existing mapping
+     */
+    private void unmap() throws RuntimeException {
+      try {
+        final Method method = FileChannelImpl.class.getDeclaredMethod("unmap0", long.class, long.class);
+        method.setAccessible(true);
+        method.invoke(fileChannel_, nativeRawStartAddress_, capacityBytes_);
+        randomAccessFile_.close();
+      } catch (final Exception e) {
+        throw new RuntimeException(
+            String.format("Encountered %s exception while freeing memory", e.getClass()));
+      }
+    }
+
+    public void run() {
+      if (fileChannel_ != null) {
+        unmap();
+      }
+
+      nativeRawStartAddress_ = 0L;
     }
   }
 }

--- a/memory/src/main/java/com/yahoo/memory/NativeMemory.java
+++ b/memory/src/main/java/com/yahoo/memory/NativeMemory.java
@@ -129,7 +129,11 @@ public class NativeMemory implements Memory {
   /**
    * Provides access to the backing store of the given writable ByteBuffer using Memory interface.
    * @param byteBuf the given writable ByteBuffer
+   *
+   * @deprecated use {@link #wrap(ByteBuffer)} which supports both readable and writable
+   * ByteBuffer
    */
+  @Deprecated
   public NativeMemory(final ByteBuffer byteBuf) {
     if (byteBuf.isReadOnly()) {
       throw new RuntimeException(
@@ -797,10 +801,6 @@ public class NativeMemory implements Memory {
    * <p>It is always safe to call this method when you are done with this class.
    */
   public void freeMemory() {
-    if (requiresFree()) {
-        unsafe.freeMemory(nativeRawStartAddress_);
-        nativeRawStartAddress_ = 0L;
-    }
     capacityBytes_ = 0L;
     memReq_ = null;
   }
@@ -839,16 +839,6 @@ public class NativeMemory implements Memory {
     }
     sb.append(String.format("%n%20s: ", j)).append(sb2).append(LS);
     return sb.toString();
-  }
-
-  /**
-   * Returns true if the object requires being freed.
-   * This method exists to standardize the check between freeMemory() and finalize()
-   *
-   * @return true if the object should be freed when it is no longer needed
-   */
-  protected boolean requiresFree() {
-    return (nativeRawStartAddress_ != 0L) && (byteBuf_ == null);
   }
 
 }

--- a/memory/src/test/java/com/yahoo/memory/MemoryMappedFileTest.java
+++ b/memory/src/test/java/com/yahoo/memory/MemoryMappedFileTest.java
@@ -78,15 +78,14 @@ public class MemoryMappedFileTest {
   @Test
   public void testMultipleUnMaps() {
     File file = new File(getClass().getClassLoader().getResource("memory_mapped.txt").getFile());
+    MemoryMappedFile mmf = null;
     try {
-      MemoryMappedFile mmf = new MemoryMappedFile(file, 0, file.length());
-      mmf.freeMemory();
-      mmf.freeMemory();
-      fail("Failed: testMultipleUnMaps()");
+      mmf = new MemoryMappedFile(file, 0, file.length());
     } catch (Exception e) {
-      // Expected
-      return;
+      fail("Failed: testMultipleUnMaps()");
     }
+    mmf.freeMemory();
+    mmf.freeMemory();
   }
 
   @Test


### PR DESCRIPTION
1. Introduce cleaner for AllocMemory and MemoryMappedFile
2. Get Rid of requireFree method
3. Fix constructors in AllocMemory
4. Remove unsafe.reallocateMemoryCalls
5. AllocMemory is now extends NativeMemory
6. Deprecate NativeMemory(ByteBuf) and instead use NativeMemory.wrap(ByteBuf)
7. Documentation Fix