### PR TITLE
Fix bug in HeapUpdatesketch.toByteArray() that didn't set ...

### DIFF
--- a/src/main/java/com/yahoo/sketches/theta/HeapUpdateSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapUpdateSketch.java
@@ -13,6 +13,7 @@ import static com.yahoo.sketches.theta.PreambleUtil.insertFamilyID;
 import static com.yahoo.sketches.theta.PreambleUtil.insertFlags;
 import static com.yahoo.sketches.theta.PreambleUtil.insertLgArrLongs;
 import static com.yahoo.sketches.theta.PreambleUtil.insertLgNomLongs;
+import static com.yahoo.sketches.theta.PreambleUtil.insertLgResizeFactor;
 import static com.yahoo.sketches.theta.PreambleUtil.insertP;
 import static com.yahoo.sketches.theta.PreambleUtil.insertPreLongs;
 import static com.yahoo.sketches.theta.PreambleUtil.insertSeedHash;
@@ -86,8 +87,8 @@ abstract class HeapUpdateSketch extends UpdateSketch {
 
     //preamble first 8 bytes. Note: only compact can be reduced to 8 bytes.
     final int lgRf = getResizeFactor().lg() & 3;
-    final byte byte0 = (byte) ((lgRf << 6) | preLongs);
-    insertPreLongs(memObj, memAdd, byte0);
+    insertPreLongs(memObj, memAdd, preLongs);
+    insertLgResizeFactor(memObj, memAdd, lgRf);
     insertSerVer(memObj, memAdd, SER_VER);
     insertFamilyID(memObj, memAdd, familyID);
     insertLgNomLongs(memObj, memAdd, getLgNomLongs());

--- a/src/test/java/com/yahoo/sketches/theta/HeapQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapQuickSelectSketchTest.java
@@ -122,6 +122,7 @@ public class HeapQuickSelectSketchTest {
     assertEquals(usk2.isEmpty(), false);
     assertEquals(usk2.isEstimationMode(), false);
     assertEquals(usk2.getClass().getSimpleName(), usk.getClass().getSimpleName());
+    assertEquals(usk2.getResizeFactor(), usk.getResizeFactor());
     usk2.toString(true, true, 8, true);
   }
 
@@ -149,6 +150,7 @@ public class HeapQuickSelectSketchTest {
     assertEquals(usk2.isEmpty(), false);
     assertEquals(usk2.isEstimationMode(), true);
     assertEquals(usk2.getClass().getSimpleName(), usk.getClass().getSimpleName());
+    assertEquals(usk2.getResizeFactor(), usk.getResizeFactor());
   }
 
   @Test


### PR DESCRIPTION
... resize factor. Could cause infinite loop if wrapping an under-full serialized sketch and updating it.