### PR TITLE
Singleton theta

### DIFF
--- a/src/main/java/com/yahoo/sketches/theta/CompactSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/CompactSketch.java
@@ -82,7 +82,7 @@ public abstract class CompactSketch extends Sketch {
       cacheOut[j++] = v;
     }
     assert curCount == j;
-    if (dstOrdered) {
+    if (dstOrdered && (curCount > 1)) {
       Arrays.sort(cacheOut);
     }
     return cacheOut;

--- a/src/main/java/com/yahoo/sketches/theta/HeapAlphaSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapAlphaSketch.java
@@ -556,7 +556,8 @@ final class HeapAlphaSketch extends HeapUpdateSketch {
     //Check lgNomLongs
     if (lgNomLongs < ALPHA_MIN_LG_NOM_LONGS) {
       throw new SketchesArgumentException(
-        "This sketch requires a minimum nominal entries of " + (1 << ALPHA_MIN_LG_NOM_LONGS));
+        "Possible corruption: This sketch requires a minimum nominal entries of "
+            + (1 << ALPHA_MIN_LG_NOM_LONGS));
     }
   }
 

--- a/src/main/java/com/yahoo/sketches/theta/HeapAnotB.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapAnotB.java
@@ -40,6 +40,14 @@ final class HeapAnotB extends AnotB {
    */
   HeapAnotB(final long seed) {
     seedHash_ = Util.computeSeedHash(seed);
+    a_ = null;
+    b_ = null;
+    thetaLong_ = Long.MAX_VALUE;
+    empty_ = true;
+    cache_ = null;
+    curCount_ = 0;
+    lgArrLongsHT_ = 5;
+    bHashTable_ = null;
   }
 
   @Override
@@ -297,12 +305,8 @@ final class HeapAnotB extends AnotB {
     bHashTable_ = null;
   }
 
-  /* (non-Javadoc)
-   * @see com.yahoo.sketches.theta.SetOperation#getCache()
-   */
   @Override
   long[] getCache() {
-    // TODO Auto-generated method stub
     return null;
   }
 

--- a/src/main/java/com/yahoo/sketches/theta/HeapCompactUnorderedSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapCompactUnorderedSketch.java
@@ -41,9 +41,9 @@ final class HeapCompactUnorderedSketch extends HeapCompactSketch {
    * Heapifies the given source Memory with seed
    * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
    * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
-   * @return this sketch
+   * @return a CompactSketch
    */
-  static HeapCompactUnorderedSketch heapifyInstance(final Memory srcMem, final long seed) {
+  static CompactSketch heapifyInstance(final Memory srcMem, final long seed) {
     final Object memObj = ((WritableMemory)srcMem).getArray(); //may be null
     final long memAdd = srcMem.getCumulativeOffset(0L);
 
@@ -59,9 +59,9 @@ final class HeapCompactUnorderedSketch extends HeapCompactSketch {
 
     if (preLongs == 1) {
       if (!empty) { //singleItem
-        curCount = 1;
-        cache = new long[] { srcMem.getLong(8) };
-      } //else empty
+        return new SingleItemSketch(srcMem.getLong(8), memSeedHash);
+      }
+      //else empty
     } else { //preLongs > 1
       curCount = extractCurCount(memObj, memAdd);
       cache = new long[curCount];
@@ -78,8 +78,9 @@ final class HeapCompactUnorderedSketch extends HeapCompactSketch {
   /**
    * Converts the given UpdateSketch to this compact form.
    * @param sketch the given UpdateSketch
+   * @return a CompactSketch
    */
-  static HeapCompactUnorderedSketch compact(final UpdateSketch sketch) {
+  static CompactSketch compact(final UpdateSketch sketch) {
     final long thetaLong = sketch.getThetaLong();
     final boolean empty = sketch.isEmpty();
     final int curCount = sketch.getRetainedEntries(true);
@@ -88,6 +89,9 @@ final class HeapCompactUnorderedSketch extends HeapCompactSketch {
     final long[] cache = sketch.getCache();
     final boolean ordered = false;
     final long[] cacheOut = CompactSketch.compactCache(cache, curCount, thetaLong, ordered);
+    if ((curCount == 1) && (thetaLong == Long.MAX_VALUE)) {
+      return new SingleItemSketch(cacheOut[0], seedHash);
+    }
     return new HeapCompactUnorderedSketch(cacheOut, empty, seedHash, curCount, thetaLong);
   }
 
@@ -100,10 +104,13 @@ final class HeapCompactUnorderedSketch extends HeapCompactSketch {
    * @param curCount correct value
    * @param thetaLong The correct
    * <a href="{@docRoot}/resources/dictionary.html#thetaLong">thetaLong</a>.
-   * @return this sketch
+   * @return a CompactSketch
    */
-  static HeapCompactUnorderedSketch compact(final long[] cache, final boolean empty,
+  static CompactSketch compact(final long[] cache, final boolean empty,
       final short seedHash, final int curCount, final long thetaLong) {
+    if ((curCount == 1) && (thetaLong == Long.MAX_VALUE)) {
+      return new SingleItemSketch(cache[0], seedHash);
+    }
     return new HeapCompactUnorderedSketch(cache, empty, seedHash, curCount, thetaLong);
   }
 

--- a/src/main/java/com/yahoo/sketches/theta/SingleItemSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/SingleItemSketch.java
@@ -48,6 +48,11 @@ public final class SingleItemSketch extends CompactSketch {
     wmem.putShort(6, computeSeedHash(seed));
   }
 
+  SingleItemSketch(final long hash, final short seedHash) {
+    arr[1] = hash;
+    wmem.putShort(6, seedHash);
+  }
+
   /**
    * Creates a SingleItemSketch on the heap given a Memory
    * @param mem the Memory to be heapified.  It must be a least 16 bytes.

--- a/src/main/java/com/yahoo/sketches/theta/UpdateSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/UpdateSketch.java
@@ -91,7 +91,7 @@ public abstract class UpdateSketch extends Sketch {
    * @return an UpdateSketch
    */
   public static UpdateSketch heapify(final Memory srcMem) {
-    return HeapQuickSelectSketch.heapifyInstance(srcMem, DEFAULT_UPDATE_SEED);
+    return heapify(srcMem, DEFAULT_UPDATE_SEED);
   }
 
   /**
@@ -101,6 +101,10 @@ public abstract class UpdateSketch extends Sketch {
    * @return an UpdateSketch
    */
   public static UpdateSketch heapify(final Memory srcMem, final long seed) {
+    final Family family = Family.idToFamily(srcMem.getByte(FAMILY_BYTE));
+    if (family.equals(Family.ALPHA)) {
+      return HeapAlphaSketch.heapifyInstance(srcMem, seed);
+    }
     return HeapQuickSelectSketch.heapifyInstance(srcMem, seed);
   }
 

--- a/src/test/java/com/yahoo/sketches/theta/ForwardCompatibilityTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/ForwardCompatibilityTest.java
@@ -103,7 +103,7 @@ public class ForwardCompatibilityTest {
     assertEquals(sketch.isOrdered(), true);
     assertEquals(sketch.getEstimate(), 1.0);
     String name = sketch.getClass().getSimpleName();
-    assertEquals(name, "HeapCompactOrderedSketch");
+    assertEquals(name, "SingleItemSketch");
   }
 
   @Test
@@ -197,8 +197,9 @@ public class ForwardCompatibilityTest {
     int serVer = v3mem.getByte(SER_VER_BYTE);
     int famId = v3mem.getByte(FAMILY_BYTE);
     int flags = v3mem.getByte(FLAGS_BYTE);
-    if ((serVer != 3) || (famId != 3) || ((flags & 24) != 24))
+    if ((serVer != 3) || (famId != 3) || ((flags & 24) != 24)) {
       throw new SketchesArgumentException("Memory must be V3, Compact, Ordered");
+    }
     //must convert v3 preamble to a v1 preamble
     int v3preLongs = v3mem.getByte(PREAMBLE_LONGS_BYTE) & 0X3F;
     int entries;
@@ -240,8 +241,9 @@ public class ForwardCompatibilityTest {
     int serVer = v3mem.getByte(SER_VER_BYTE);
     int famId = v3mem.getByte(FAMILY_BYTE);
     int flags = v3mem.getByte(FLAGS_BYTE);
-    if ((serVer != 3) || (famId != 3) || ((flags & 24) != 24))
+    if ((serVer != 3) || (famId != 3) || ((flags & 24) != 24)) {
       throw new SketchesArgumentException("Memory must be V3, Compact, Ordered");
+    }
     //compute size
     int preLongs = v3mem.getByte(PREAMBLE_LONGS_BYTE) & 0X3F;
     int entries = (preLongs == 1)? 0 : v3mem.getInt(RETAINED_ENTRIES_INT);

--- a/src/test/java/com/yahoo/sketches/theta/HeapAlphaSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAlphaSketchTest.java
@@ -11,6 +11,7 @@ import static com.yahoo.sketches.ResizeFactor.X8;
 import static com.yahoo.sketches.Util.DEFAULT_UPDATE_SEED;
 import static com.yahoo.sketches.theta.PreambleUtil.FAMILY_BYTE;
 import static com.yahoo.sketches.theta.PreambleUtil.FLAGS_BYTE;
+import static com.yahoo.sketches.theta.PreambleUtil.LG_NOM_LONGS_BYTE;
 import static com.yahoo.sketches.theta.PreambleUtil.PREAMBLE_LONGS_BYTE;
 import static com.yahoo.sketches.theta.PreambleUtil.SER_VER_BYTE;
 import static com.yahoo.sketches.theta.PreambleUtil.THETA_LONG;
@@ -42,7 +43,8 @@ public class HeapAlphaSketchTest {
     int k = 512;
     int u = k;
     long seed = DEFAULT_UPDATE_SEED;
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed)
+        .setNominalEntries(k).build();
     HeapAlphaSketch sk1 = (HeapAlphaSketch)usk; //for internal checks
 
     assertTrue(usk.isEmpty());
@@ -79,7 +81,8 @@ public class HeapAlphaSketchTest {
     int k = 512;
     int u = k;
     long seed = DEFAULT_UPDATE_SEED;
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed)
+        .setNominalEntries(k).build();
     HeapAlphaSketch sk1 = (HeapAlphaSketch)usk; //for internal checks
     assertTrue(usk.isEmpty());
 
@@ -103,7 +106,8 @@ public class HeapAlphaSketchTest {
     int k = 512;
     long seed1 = 1021;
     long seed2 = DEFAULT_UPDATE_SEED;
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed1).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed1)
+        .setNominalEntries(k).build();
     byte[] byteArray = usk.toByteArray();
     Memory srcMem = Memory.wrap(byteArray);
     Sketch.heapify(srcMem, seed2);
@@ -114,7 +118,8 @@ public class HeapAlphaSketchTest {
     int k = 512;
     int u = k;
     long seed = DEFAULT_UPDATE_SEED;
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed)
+        .setNominalEntries(k).build();
 
     for (int i=0; i<u; i++) {
       usk.update(i);
@@ -141,7 +146,8 @@ public class HeapAlphaSketchTest {
     int u = 2*k;
     long seed = DEFAULT_UPDATE_SEED;
 
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setSeed(seed)
+        .setNominalEntries(k).build();
 
     for (int i=0; i<u; i++) {
       usk.update(i);
@@ -171,7 +177,8 @@ public class HeapAlphaSketchTest {
     boolean estimating = (u > k);
     //int maxBytes = (k << 4) + (Family.ALPHA.getLowPreLongs());
 
-    UpdateSketch sk1 = UpdateSketch.builder().setFamily(fam_).setSeed(seed).setNominalEntries(k).build();
+    UpdateSketch sk1 = UpdateSketch.builder().setFamily(fam_).setSeed(seed)
+        .setNominalEntries(k).build();
 
     for (int i=0; i<u; i++) {
       sk1.update(i);
@@ -334,7 +341,8 @@ public class HeapAlphaSketchTest {
   public void checkEstMode() {
     int k = 4096;
     int u = 2*k;
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(ResizeFactor.X4).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(ResizeFactor.X4)
+        .setNominalEntries(k).build();
     HeapAlphaSketch sk1 = (HeapAlphaSketch)usk; //for internal checks
 
     assertTrue(usk.isEmpty());
@@ -352,7 +360,8 @@ public class HeapAlphaSketchTest {
     int u = k;
     float p = (float)0.5;
 
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setP(p).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setP(p)
+        .setNominalEntries(k).build();
     HeapAlphaSketch sk1 = (HeapAlphaSketch)usk; //for internal checks
 
     for (int i = 0; i < u; i++ ) {
@@ -376,7 +385,8 @@ public class HeapAlphaSketchTest {
   public void checkErrorBounds() {
     int k = 512;
 
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(X1).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(X1)
+        .setNominalEntries(k).build();
 
     //Exact mode
     for (int i = 0; i < k; i++ ) {
@@ -417,7 +427,8 @@ public class HeapAlphaSketchTest {
     assertFalse(usk.isEmpty());
 
     //virgin, p = .001
-    UpdateSketch usk2 = UpdateSketch.builder().setFamily(fam_).setP((float)0.001).setNominalEntries(k).build();
+    UpdateSketch usk2 = UpdateSketch.builder().setFamily(fam_).setP((float)0.001)
+        .setNominalEntries(k).build();
     sk1 = (HeapAlphaSketch)usk2;
     assertTrue(usk2.isEmpty());
     usk2.update(1); //will be rejected
@@ -439,7 +450,8 @@ public class HeapAlphaSketchTest {
     int k = 512;
     int u = 2*k;
 
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(X2).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(X2)
+        .setNominalEntries(k).build();
 
     for (int i = 0; i < u; i++ ) {
       usk.update(i);
@@ -481,7 +493,8 @@ public class HeapAlphaSketchTest {
     int k = 1024;
     int u = 4*k;
 
-    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(X8).setNominalEntries(k).build();
+    UpdateSketch usk = UpdateSketch.builder().setFamily(fam_).setResizeFactor(X8)
+        .setNominalEntries(k).build();
     HeapAlphaSketch sk1 = (HeapAlphaSketch)usk; //for internal checks
 
     assertTrue(usk.isEmpty());
@@ -496,7 +509,8 @@ public class HeapAlphaSketchTest {
     int subMul = Util.startingSubMultiple(11, rf, 5); //messy
     assertEquals(sk1.getLgArrLongs(), subMul);
 
-    UpdateSketch usk2 = UpdateSketch.builder().setFamily(fam_).setResizeFactor(ResizeFactor.X1).setNominalEntries(k).build();
+    UpdateSketch usk2 = UpdateSketch.builder().setFamily(fam_)
+        .setResizeFactor(ResizeFactor.X1).setNominalEntries(k).build();
     sk1 = (HeapAlphaSketch)usk2;
 
     for (int i=0; i<u; i++) {
@@ -621,7 +635,8 @@ public class HeapAlphaSketchTest {
 
   @Test
   public void checkEnhancedHashInsertOnFullHashTable() {
-    final HeapAlphaSketch alpha = (HeapAlphaSketch) UpdateSketch.builder().setFamily(ALPHA).build();
+    final HeapAlphaSketch alpha = (HeapAlphaSketch) UpdateSketch.builder()
+        .setFamily(ALPHA).build();
     final int n = 1 << alpha.getLgArrLongs();
 
     final long[] hashTable = new long[n];
@@ -643,7 +658,18 @@ public class HeapAlphaSketchTest {
     assertEquals(sketch.getFamily(), Family.ALPHA);
   }
 
-
+  @SuppressWarnings("unused")
+  @Test(expectedExceptions = SketchesArgumentException.class)
+  public void corruptionLgNomLongs() {
+    final int k = 512;
+    UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(k)
+        .setFamily(ALPHA).build();
+    for (int i = 0; i < k; i++) { sketch.update(i); }
+    byte[] byteArr = sketch.toByteArray();
+    WritableMemory wmem = WritableMemory.wrap(byteArr);
+    wmem.putByte(LG_NOM_LONGS_BYTE, (byte) 8); //corrupt LgNomLongs
+    UpdateSketch sk = Sketches.heapifyUpdateSketch(wmem);
+  }
 
   @Test
   public void printlnTest() {

--- a/src/test/java/com/yahoo/sketches/theta/HeapAlphaSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAlphaSketchTest.java
@@ -643,6 +643,8 @@ public class HeapAlphaSketchTest {
     assertEquals(sketch.getFamily(), Family.ALPHA);
   }
 
+
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());

--- a/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
@@ -4,8 +4,10 @@
  */
 package com.yahoo.sketches.theta;
 
+import static com.yahoo.sketches.Util.DEFAULT_UPDATE_SEED;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import org.testng.annotations.Test;
@@ -18,43 +20,53 @@ import com.yahoo.sketches.Util;
  * @author Lee Rhodes
  */
 public class HeapAnotBTest {
-  
+
   @Test
   public void checkExactAnotB_AvalidNoOverlap() {
     int k = 512;
-    
+
     UpdateSketch usk1 = UpdateSketch.builder().setNominalEntries(k).build();
     UpdateSketch usk2 = UpdateSketch.builder().setNominalEntries(k).build();
-    
-    for (int i=0; i<k/2; i++) usk1.update(i);
-    for (int i=k/2; i<k; i++) usk2.update(i);
-    
+
+    for (int i=0; i<(k/2); i++) {
+      usk1.update(i);
+    }
+    for (int i=k/2; i<k; i++) {
+      usk2.update(i);
+    }
+
     AnotB aNb = SetOperation.builder().buildANotB();
+    assertTrue(aNb.isEmpty());
+    assertNull(aNb.getCache());
+    assertEquals(aNb.getThetaLong(), Long.MAX_VALUE);
+    assertEquals(aNb.getSeedHash(), Util.computeSeedHash(DEFAULT_UPDATE_SEED));
+
     aNb.update(usk1, usk2);
-    
+    assertEquals(aNb.getRetainedEntries(true), 256);
+
     CompactSketch rsk1;
-    
+
     rsk1 = aNb.getResult(false, null);
     assertEquals(rsk1.getEstimate(), k/2.0);
-    
+
     aNb.update(usk1, usk2);
     rsk1 = aNb.getResult(true, null);
     assertEquals(rsk1.getEstimate(), k/2.0);
-    
+
     //getCurrentBytes( compact )
     int bytes = rsk1.getCurrentBytes(true);
     byte[] byteArray = new byte[bytes];
     WritableMemory mem = WritableMemory.wrap(byteArray);
-    
+
     aNb.update(usk1, usk2);
     rsk1 = aNb.getResult(false, mem);
     assertEquals(rsk1.getEstimate(), k/2.0);
-    
+
     aNb.update(usk1, usk2);
     rsk1 = aNb.getResult(true, mem);
     assertEquals(rsk1.getEstimate(), k/2.0);
   }
-  
+
   @Test
   public void checkCombinations() {
     int k = 512;
@@ -62,21 +74,26 @@ public class HeapAnotBTest {
     UpdateSketch bNull = null;
     UpdateSketch aEmpty = UpdateSketch.builder().setNominalEntries(k).build();
     UpdateSketch bEmpty = UpdateSketch.builder().setNominalEntries(k).build();
-    
+
     UpdateSketch aHT = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=0; i<k; i++) aHT.update(i);
+    for (int i=0; i<k; i++) {
+      aHT.update(i);
+    }
     CompactSketch aC = aHT.compact(false, null);
     CompactSketch aO = aHT.compact(true,  null);
-    
+
     UpdateSketch bHT = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=k/2; i<(k+k/2); i++) bHT.update(i); //overlap is k/2
+    for (int i=k/2; i<(k+(k/2)); i++)
+     {
+      bHT.update(i); //overlap is k/2
+    }
     CompactSketch bC = bHT.compact(false, null);
     CompactSketch bO = bHT.compact(true,  null);
-    
+
     CompactSketch res;
     AnotB aNb;
     boolean ordered = true;
-    
+
     aNb = SetOperation.builder().buildANotB();
 
     aNb.update(aNull, bNull);
@@ -84,252 +101,270 @@ public class HeapAnotBTest {
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aNull, bEmpty);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aNull, bC);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aNull, bO);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aNull, bHT);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
-    
+
+
     aNb.update(aEmpty, bNull);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aEmpty, bEmpty);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aEmpty, bC);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aEmpty, bO);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aEmpty, bHT);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), 0.0);
     assertTrue(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
-    
+
+
     aNb.update(aC, bNull);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aC, bEmpty);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aC, bC);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aC, bO);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aC, bHT);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
-    
+
+
     aNb.update(aO, bNull);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aO, bEmpty);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aO, bC);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aO, bO);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aO, bHT);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
-    
+
+
     aNb.update(aHT, bNull);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aHT, bEmpty);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aHT, bC);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aHT, bO);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
-    
+
     aNb.update(aHT, bHT);
     res = aNb.getResult(!ordered, null);
     assertEquals(res.getEstimate(), (double) k/2);
     assertFalse(res.isEmpty());
     assertEquals(res.getThetaLong(), Long.MAX_VALUE);
   }
-  
+
   @Test
   public void checkAnotBnotC() {
     int k = 1024;
     boolean ordered = true;
-    
+
     UpdateSketch aU = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=0; i<k; i++) aU.update(i);        //All 1024
-    
+    for (int i=0; i<k; i++)
+     {
+      aU.update(i);        //All 1024
+    }
+
     UpdateSketch bU = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=0; i<k/2; i++) bU.update(i);      //512
-    
+    for (int i=0; i<(k/2); i++)
+     {
+      bU.update(i);      //512
+    }
+
     UpdateSketch cU = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=k/2; i<3*k/4; i++) cU.update(i);  //256
-    
+    for (int i=k/2; i<((3*k)/4); i++)
+     {
+      cU.update(i);  //256
+    }
+
     int memBytes = Sketch.getMaxUpdateSketchBytes(k);
     CompactSketch r1, r2;
-    
+
     byte[] memArr1 = new byte[memBytes];
     byte[] memArr2 = new byte[memBytes];
     WritableMemory mem1 = WritableMemory.wrap(memArr1);
     WritableMemory mem2 = WritableMemory.wrap(memArr2);
-    
+
     AnotB aNb = SetOperation.builder().buildANotB();
     aNb.update(aU, bU);
     r1 = aNb.getResult(ordered, mem1);
-    
+
     aNb.update(r1, cU);
     r2 = aNb.getResult(ordered, mem2);
     double est = r2.getEstimate();
     println("est: "+est);
     assertEquals(est, k/4.0, 0.0);
   }
-  
+
   @Test
   public void checkAnotBnotC_sameMemory() {
     int k = 1024;
     boolean ordered = true;
-    
+
     UpdateSketch a = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=0; i<k; i++) a.update(i);        //All 1024
-    
+    for (int i=0; i<k; i++)
+     {
+      a.update(i);        //All 1024
+    }
+
     UpdateSketch b = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=0; i<k/2; i++) b.update(i);      //512
-    
+    for (int i=0; i<(k/2); i++)
+     {
+      b.update(i);      //512
+    }
+
     UpdateSketch c = UpdateSketch.builder().setNominalEntries(k).build();
-    for (int i=k/2; i<3*k/4; i++) c.update(i);  //256
-    
+    for (int i=k/2; i<((3*k)/4); i++)
+     {
+      c.update(i);  //256
+    }
+
     int memBytes = Sketch.getMaxCompactSketchBytes(a.getCurrentBytes(true));
-    
+
     byte[] memArr = new byte[memBytes];
     WritableMemory mem = WritableMemory.wrap(memArr);
-    
+
     CompactSketch r;
     AnotB aNb = SetOperation.builder().buildANotB();
-    
+
     //Iterative loop: {
     aNb.update(a, b);
     r = aNb.getResult(ordered, mem);
-    
+
     aNb.update(r, c);
     r = aNb.getResult(ordered, mem);
     //}
-    
+
     double est = r.getEstimate();
     println("est: "+est);
     assertEquals(est, k/4.0, 0.0);
   }
-  
+
   @Test
   public void checkGetResult() {
     UpdateSketch skA = Sketches.updateSketchBuilder().build();
     UpdateSketch skB = Sketches.updateSketchBuilder().build();
-  
+
     AnotB aNotB = Sketches.setOperationBuilder().buildANotB();
     aNotB.update(skA, skB);
     CompactSketch csk = aNotB.getResult();
     assertEquals(csk.getCurrentBytes(true), 8);
   }
-  
+
   @Test
   public void checkGetFamily() {
     //cheap trick
     HeapAnotB anotb = new HeapAnotB(Util.DEFAULT_UPDATE_SEED);
     assertEquals(anotb.getFamily(), Family.A_NOT_B);
   }
-  
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
@@ -145,7 +145,7 @@ public class SketchesTest {
     Union union = setOperationBuilder().buildUnion();
     byte[] byteArr = union.toByteArray();
     Memory srcMem = Memory.wrap(byteArr);
-    Sketches.getEstimate(srcMem);
+    Sketches.getEstimate(srcMem); //Union is not a Theta Sketch, it is an operation
   }
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/UnionImplTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/UnionImplTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
+import com.yahoo.sketches.Util;
 
 public class UnionImplTest {
 
@@ -139,6 +140,16 @@ public class UnionImplTest {
 
     Union union2 = SetOperation.builder().buildUnion(); //on-heap union
     assertFalse(union2.isSameResource(wmem2));  //obviously not
+  }
+
+  @Test
+  public void checkRestricted() {
+    Union union = Sketches.setOperationBuilder().buildUnion();
+    assertTrue(union.isEmpty());
+    assertEquals(union.getThetaLong(), Long.MAX_VALUE);
+    assertEquals(union.getSeedHash(), Util.computeSeedHash(DEFAULT_UPDATE_SEED));
+    assertEquals(union.getRetainedEntries(true), 0);
+    assertEquals(union.getCache().length, 128);
   }
 
   @Test


### PR DESCRIPTION
I was suspicious that the SingleItemSketch was still not completely implemented.  So I created tests that checked all the different set operations and on-and off heap.  Sure enough, there were some gaps.  Any circumstance where a CompactSketch ends up with only one entry should result in a SingleItemSketch.  This now works.  Along the way I found a bug with the AlphaSketch where it wasn't able to heapify.  This is also fixed.  Also the initialization of the AnotB operation was not quite correct so I fixed that.   I also added some more unit tests for the Theta package where I found opportunities to do so.   Most users would never see these new discrepancies I found. 