### PR TITLE
Respect comparator in items sketch

### DIFF
--- a/src/main/java/com/yahoo/sketches/quantiles/ItemsPmfCdfImpl.java
+++ b/src/main/java/com/yahoo/sketches/quantiles/ItemsPmfCdfImpl.java
@@ -6,7 +6,9 @@
 package com.yahoo.sketches.quantiles;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 class ItemsPmfCdfImpl {
 
@@ -51,7 +53,8 @@ class ItemsPmfCdfImpl {
       ItemsPmfCdfImpl.bilinearTimeIncrementHistogramCounters(
           (T[]) samples, 0, bbCount, weight, splitPoints, counters, sketch.getComparator());
     } else {
-      Arrays.sort(samples, 0, bbCount);
+      final List targets = Arrays.asList(samples).subList(0, bbCount);
+      Collections.sort(targets, sketch.getComparator());
       // sort is worth it when many split points
       linearTimeIncrementHistogramCounters(
           (T[]) samples, 0, bbCount, weight, splitPoints, counters, sketch.getComparator()

--- a/src/main/java/com/yahoo/sketches/quantiles/ItemsUtil.java
+++ b/src/main/java/com/yahoo/sketches/quantiles/ItemsUtil.java
@@ -6,7 +6,9 @@
 package com.yahoo.sketches.quantiles;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 
 import com.yahoo.sketches.SketchesArgumentException;
 
@@ -69,8 +71,8 @@ final class ItemsUtil {
 
     // this aliasing is a bit dangerous; notice that we did it after the possible resizing
     final Object[] baseBuffer = sketch.getCombinedBuffer();
-
-    Arrays.sort(baseBuffer, 0, bbCount);
+    final List targets = Arrays.asList(baseBuffer).subList(0, bbCount);
+    Collections.sort(targets, sketch.getComparator());
     ItemsUpdateImpl.inPlacePropagateCarry(
         0,
         null, 0,  // this null is okay


### PR DESCRIPTION
comparator handed over to items sketch is not used when sorting, making exception "Values must be unique, monotonically increasing and not NaN."