### PR TITLE
Use thread local random instead of global, shared one

### DIFF
--- a/src/main/java/com/yahoo/sketches/quantiles/ItemsMergeImpl.java
+++ b/src/main/java/com/yahoo/sketches/quantiles/ItemsMergeImpl.java
@@ -191,7 +191,7 @@ final class ItemsMergeImpl {
       final T[] bufC, final int startC, // output
       final int kC, // number of items that should be in the output
       final int stride) {
-    final int randomOffset = ItemsSketch.rand.nextInt(stride);
+    final int randomOffset = ItemsSketch.rand.get().nextInt(stride);
     final int limC = startC + kC;
     for (int a = startSrc + randomOffset, c = startC; c < limC; a += stride, c++ ) {
       bufC[c] = bufSrc[a];

--- a/src/main/java/com/yahoo/sketches/quantiles/ItemsSketch.java
+++ b/src/main/java/com/yahoo/sketches/quantiles/ItemsSketch.java
@@ -106,7 +106,14 @@ public final class ItemsSketch<T> {
    * received in exactly the same order. This is only useful when performing test comparisons,
    * otherwise is not recommended.
    */
-  public static final Random rand = new Random();
+  public static final ThreadLocal<Random> rand = new ThreadLocal<Random>()
+  {
+    @Override
+    protected Random initialValue()
+    {
+      return new Random();
+    }
+  };
 
   private ItemsSketch(final int k, final Comparator<? super T> comparator) {
     Util.checkK(k);

--- a/src/main/java/com/yahoo/sketches/quantiles/ItemsUpdateImpl.java
+++ b/src/main/java/com/yahoo/sketches/quantiles/ItemsUpdateImpl.java
@@ -84,7 +84,7 @@ final class ItemsUpdateImpl {
       final Object[] bufA, final int startA, // input
       final Object[] bufC, final int startC, // output
       final int k) {
-    final int randomOffset = ItemsSketch.rand.nextBoolean() ? 1 : 0;
+    final int randomOffset = ItemsSketch.rand.get().nextBoolean() ? 1 : 0;
     final int limC = startC + k;
     for (int a = startA + randomOffset, c = startC; c < limC; a += 2, c++) {
       bufC[c] = bufA[a];

--- a/src/test/java/com/yahoo/sketches/quantiles/ItemsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/ItemsSketchTest.java
@@ -27,7 +27,7 @@ public class ItemsSketchTest {
 
   @BeforeMethod
   public void setUp() {
-    ItemsSketch.rand.setSeed(32749); // make sketches deterministic for testing
+    ItemsSketch.rand.get().setSeed(32749); // make sketches deterministic for testing
   }
 
   @Test
@@ -491,7 +491,7 @@ public class ItemsSketchTest {
     for (Comparator<String> c : Arrays.asList(natural, reverse, numeric)) {
       final ItemsSketch<String> sketch = ItemsSketch.getInstance(16, c);
       for (int i = 0; i < 10000; i++) {
-        sketch.update(String.valueOf(ItemsSketch.rand.nextInt(1000000)));
+        sketch.update(String.valueOf(ItemsSketch.rand.get().nextInt(1000000)));
       }
       final String[] quantiles = sketch.getQuantiles(100);
       final String[] sorted = Arrays.copyOf(quantiles, quantiles.length);


### PR DESCRIPTION
Sometimes it's required to get determinitic result from sketches. But currently random instance in ItemsSketch is static one and hard to provide seed for that purpose in multi-threaded env. And also, java doc in Random class sugests to use thread-local to avoid contention.