### PR TITLE
Eshcar conc theta

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,12 @@
             <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/yahoo/sketches/theta/ConcurrentThetaContext.java
+++ b/src/main/java/com/yahoo/sketches/theta/ConcurrentThetaContext.java
@@ -1,0 +1,65 @@
+package com.yahoo.sketches.theta;
+
+import com.yahoo.sketches.theta.CompactSketch;
+import com.yahoo.sketches.theta.ConcurrentUpdateSketch;
+import com.yahoo.sketches.theta.UpdateReturnState;
+import com.yahoo.sketches.theta.UpdateSketch;
+import com.yahoo.sketches.theta.UpdateSketchBuilder;
+import com.yahoo.sketches.theta.UpdateSketchComposition;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author eshcar
+ */
+public class ConcurrentThetaContext extends UpdateSketchComposition {
+
+  UpdateSketch localSketch_;
+  private AtomicBoolean propagationInProgress_;
+
+  ConcurrentThetaContext(ConcurrentUpdateSketch shared, UpdateSketch local) {
+    super(shared);
+    localSketch_ = local;
+    propagationInProgress_ = new AtomicBoolean(false);
+    localSketch_.setThetaLong(shared.getVolatileTheta());
+  }
+
+  ConcurrentThetaContext(ConcurrentUpdateSketch shared, UpdateSketchBuilder usb) {
+    super(shared);
+    localSketch_ = usb.build();
+    propagationInProgress_ = new AtomicBoolean(false);
+    localSketch_.setThetaLong(shared.getVolatileTheta());
+  }
+
+  public ConcurrentUpdateSketch getSharedSketch() {
+    return (ConcurrentUpdateSketch) delegatee_;
+  }
+
+
+  @Override
+  UpdateReturnState hashUpdate(final long hash) {
+    UpdateReturnState ret = localSketch_.hashUpdate(hash);
+    if (localSketch_.isOutOfSpace(localSketch_.getRetainedEntries(false)+1)
+        && localSketch_.getLgArrLongs() > localSketch_.getLgNomLongs()) {
+        // local theta is going to be changed upon next update
+        propagateToSharedSketch();
+    }
+    return ret;
+  }
+
+  @Override
+  public double getEstimate() {
+    return getSharedSketch().getEstimationSnapshot();
+  }
+
+  private void propagateToSharedSketch() {
+    while (propagationInProgress_.get()) {} //busy wait
+
+    CompactSketch compactSketch = localSketch_.compact();
+    propagationInProgress_.set(true);
+    getSharedSketch().propagate(compactSketch, propagationInProgress_);
+    localSketch_.reset();
+    localSketch_.setThetaLong(getSharedSketch().getVolatileTheta());
+  }
+
+}

--- a/src/main/java/com/yahoo/sketches/theta/ConcurrentThetaFactory.java
+++ b/src/main/java/com/yahoo/sketches/theta/ConcurrentThetaFactory.java
@@ -1,0 +1,30 @@
+package com.yahoo.sketches.theta;
+
+import com.yahoo.sketches.Family;
+
+/**
+ * @author eshcar
+ */
+public class ConcurrentThetaFactory {
+
+  static public ConcurrentUpdateSketch createConcurrentUpdateSketch(Family family) {
+    UpdateSketchBuilder usb = new UpdateSketchBuilder();
+    usb.setFamily(family);
+    UpdateSketch sketch = usb.build();
+    return new ConcurrentUpdateSketch(sketch);
+  }
+
+  static public ConcurrentThetaContext createConcurrentThetaContext(ConcurrentUpdateSketch shared) {
+    UpdateSketchBuilder usb = new UpdateSketchBuilder();
+    Family family = shared.getFamily();
+    usb.setFamily(family);
+    UpdateSketch local = usb.build();
+//    return new ConcurrentThetaContext(shared, usb);
+    return new ConcurrentThetaContext(shared, local);
+  }
+
+  public static ConcurrentUpdateSketch createConcurrentUpdateSketch(UpdateSketch sketch) {
+    return new ConcurrentUpdateSketch(sketch);
+  }
+
+}

--- a/src/main/java/com/yahoo/sketches/theta/ConcurrentUpdateSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/ConcurrentUpdateSketch.java
@@ -1,0 +1,86 @@
+package com.yahoo.sketches.theta;
+
+import com.yahoo.sketches.theta.Sketch;
+import com.yahoo.sketches.theta.UpdateSketch;
+import com.yahoo.sketches.theta.UpdateSketchComposition;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author eshcar
+ */
+public class ConcurrentUpdateSketch extends UpdateSketchComposition {
+
+  private static int PARALLELISM_LEVEL = 3;
+  protected static ExecutorService PROPAGATION_EXECUTOR_SERVICE = Executors.newWorkStealingPool
+      (PARALLELISM_LEVEL);
+
+  private volatile long theta_;
+  private volatile double estimation_;
+  // A flag to coordinate between several propagation threads
+  private AtomicBoolean propagationInProgress_;
+
+  // package visibility constructors - to be created only by factory
+  ConcurrentUpdateSketch(final UpdateSketch delegattee) {
+    super(delegattee);
+    theta_ = getThetaLong();
+    estimation_ = 0;
+    propagationInProgress_ = new AtomicBoolean(false);
+  }
+
+  public void propagate(final Sketch sketchIn, AtomicBoolean propagationInProgress) {
+    BackgroundThetaPropagation job = new BackgroundThetaPropagation(sketchIn,
+        propagationInProgress);
+    PROPAGATION_EXECUTOR_SERVICE.execute(job);
+  }
+
+  public double getEstimationSnapshot() {
+    return estimation_;
+  }
+
+  public long getVolatileTheta() {
+    return theta_;
+  }
+
+  private class BackgroundThetaPropagation implements Runnable {
+
+    private Sketch sketch_;
+    private AtomicBoolean localThreadPropagationFlag_;
+
+    public BackgroundThetaPropagation(Sketch sketch, AtomicBoolean localThreadPropagationFlag) {
+      this.sketch_ = sketch;
+      this.localThreadPropagationFlag_ = localThreadPropagationFlag;
+    }
+
+    @Override public void run() {
+      assert getVolatileTheta() <= sketch_.getThetaLong();
+
+      while(!propagationInProgress_.compareAndSet(false,true)) {
+        //busy wait until can propagate
+      }
+      //At this point we are sure only a single thread is propagating data to the shared sketch
+
+      // propagate values from input sketch one by one
+      final long[] cacheIn = sketch_.getCache();
+      final int numEntries = sketch_.getRetainedEntries(false);
+      for (int i = 0; i < numEntries; i++) {
+        // pre-condition: cacheIn values are sorted in ascending order
+        final long hashIn = cacheIn[i];
+        if (hashIn >= getVolatileTheta()) {
+          break; //early stop
+        }
+        hashUpdate(hashIn); // backdoor update, hash function is bypassed
+      }
+
+      //update volatile theta, uniques estimate and propagation flag
+      theta_ = getThetaLong();
+      estimation_ = getEstimate();
+      //propagation completed, not in-progress, set both local and shared flags
+      propagationInProgress_.set(false);
+      localThreadPropagationFlag_.set(false);
+    }
+  }
+
+}

--- a/src/main/java/com/yahoo/sketches/theta/DirectQuickSelectSketchR.java
+++ b/src/main/java/com/yahoo/sketches/theta/DirectQuickSelectSketchR.java
@@ -252,4 +252,14 @@ class DirectQuickSelectSketchR extends UpdateSketch {
     return (int) Math.floor(fraction * (1 << lgArrLongs));
   }
 
+  @Override
+  void setThetaLong(long thetaLong) {
+    mem_.putLong(THETA_LONG, thetaLong);
+  }
+
+  @Override
+  boolean isOutOfSpace(int numEntries) {
+    return numEntries > hashTableThreshold_;
+  }
+
 }

--- a/src/main/java/com/yahoo/sketches/theta/HeapAlphaSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapAlphaSketch.java
@@ -257,6 +257,16 @@ final class HeapAlphaSketch extends HeapUpdateSketch {
   }
 
   @Override
+  void setThetaLong(long theta) {
+    thetaLong_ = theta;
+  }
+
+  @Override
+  boolean isOutOfSpace(int numEntries) {
+    return numEntries > hashTableThreshold_;
+  }
+
+  @Override
   long[] getCache() {
     return cache_;
   }
@@ -310,7 +320,7 @@ final class HeapAlphaSketch extends HeapUpdateSketch {
       else {
         //inserts (not entries!) <= k. It may not be at tgt size.
         //Check size, don't decrement theta. cnt already ++, empty_ already false;
-        if (curCount_ > hashTableThreshold_) {
+        if (isOutOfSpace(curCount_)) {
           resizeClean(); //not dirty, not at tgt size.
         }
       }

--- a/src/main/java/com/yahoo/sketches/theta/HeapQuickSelectSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapQuickSelectSketch.java
@@ -197,6 +197,16 @@ final class HeapQuickSelectSketch extends HeapUpdateSketch {
   }
 
   @Override
+  void setThetaLong(long theta) {
+    thetaLong_ = theta;
+  }
+
+  @Override
+  boolean isOutOfSpace(int numEntries) {
+    return numEntries > hashTableThreshold_;
+  }
+
+  @Override
   long[] getCache() {
     return cache_;
   }
@@ -233,7 +243,7 @@ final class HeapQuickSelectSketch extends HeapUpdateSketch {
     //insertion occurred, must increment curCount
     curCount_++;
 
-    if (curCount_ > hashTableThreshold_) { //we need to do something, we are out of space
+    if (isOutOfSpace(curCount_)) { //we need to do something, we are out of space
       //must rebuild or resize
       if (lgArrLongs_ <= lgNomLongs_) { //resize
         resizeCache();

--- a/src/main/java/com/yahoo/sketches/theta/UpdateSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/UpdateSketch.java
@@ -439,4 +439,7 @@ public abstract class UpdateSketch extends Sketch {
     }
   }
 
+  abstract void setThetaLong(long theta);
+
+  abstract boolean isOutOfSpace(int numEntries);
 }

--- a/src/main/java/com/yahoo/sketches/theta/UpdateSketchComposition.java
+++ b/src/main/java/com/yahoo/sketches/theta/UpdateSketchComposition.java
@@ -1,0 +1,107 @@
+package com.yahoo.sketches.theta;
+
+import com.yahoo.memory.WritableMemory;
+import com.yahoo.sketches.Family;
+import com.yahoo.sketches.ResizeFactor;
+import com.yahoo.sketches.theta.UpdateReturnState;
+import com.yahoo.sketches.theta.UpdateSketch;
+
+/**
+ * @author eshcar
+ */
+public class UpdateSketchComposition extends UpdateSketch {
+  protected UpdateSketch delegatee_;
+
+  protected UpdateSketchComposition(final UpdateSketch delegattee) {
+    super();
+    delegatee_ = delegattee;
+  }
+
+  @Override public int getCurrentBytes(boolean compact) {
+    return delegatee_.getCurrentBytes(compact);
+  }
+
+  @Override public Family getFamily() {
+    return delegatee_.getFamily();
+  }
+
+  @Override public int getRetainedEntries(boolean valid) {
+    return delegatee_.getRetainedEntries(valid);
+  }
+
+  @Override public boolean isDirect() {
+    return delegatee_.isDirect();
+  }
+
+  @Override public boolean isEmpty() {
+    return delegatee_.isEmpty();
+  }
+
+  @Override public byte[] toByteArray() {
+    return delegatee_.toByteArray();
+  }
+
+  @Override long[] getCache() {
+    return delegatee_.getCache();
+  }
+
+  @Override int getCurrentPreambleLongs(boolean compact) {
+    return delegatee_.getCurrentPreambleLongs(compact);
+  }
+
+  @Override short getSeedHash() {
+    return delegatee_.getSeedHash();
+  }
+
+  @Override long getThetaLong() {
+    return delegatee_.getThetaLong();
+  }
+
+  @Override public void reset() {
+    delegatee_.reset();
+  }
+
+  @Override public UpdateSketch rebuild() {
+    return delegatee_.rebuild();
+  }
+
+  @Override public ResizeFactor getResizeFactor() {
+    return delegatee_.getResizeFactor();
+  }
+
+  @Override UpdateReturnState hashUpdate(long hash) {
+    return delegatee_.hashUpdate(hash);
+  }
+
+  @Override int getLgArrLongs() {
+    return delegatee_.getLgArrLongs();
+  }
+
+  @Override public int getLgNomLongs() {
+    return delegatee_.getLgNomLongs();
+  }
+
+  @Override float getP() {
+    return delegatee_.getP();
+  }
+
+  @Override long getSeed() {
+    return delegatee_.getSeed();
+  }
+
+  @Override boolean isDirty() {
+    return delegatee_.isDirty();
+  }
+
+  @Override WritableMemory getMemory() {
+    return delegatee_.getMemory();
+  }
+
+  @Override void setThetaLong(long theta) {
+    delegatee_.setThetaLong(theta);
+  }
+
+  @Override boolean isOutOfSpace(int numEntries) {
+    return delegatee_.isOutOfSpace(numEntries);
+  }
+}

--- a/src/test/java/com/yahoo/sketches/concurrent/ConcurrentTestContext.java
+++ b/src/test/java/com/yahoo/sketches/concurrent/ConcurrentTestContext.java
@@ -1,0 +1,66 @@
+package com.yahoo.sketches.concurrent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * @author eshcar
+ */
+public class ConcurrentTestContext {
+  private static final Log LOG = LogFactory.getLog(ConcurrentTestContext.class);
+
+  private Throwable err_ = null;
+  private Set<ConcurrentTestThread> testThreads_ = new HashSet<ConcurrentTestThread>();
+
+  public void addThread(ConcurrentTestThread t) {
+   	testThreads_.add(t);
+  }
+
+  public void startThreads() {
+    for (ConcurrentTestThread t : testThreads_) {
+    		t.start();
+    }
+
+
+    for (ConcurrentTestThread t : testThreads_) {
+    	t.startThread();
+    }
+  }
+
+  private synchronized void checkException() throws Exception {
+    if (err_ != null) {
+  	  throw new RuntimeException("Deferred", err_);
+  	}
+  }
+
+  public synchronized void threadFailed(Throwable t) {
+    if (err_ == null)
+    	err_ = t;
+    LOG.error("Failed!", err_);
+    notify();
+  }
+
+  public void stop() throws Exception {
+    for (ConcurrentTestThread t : testThreads_) {
+      t.stopThread();
+    }
+
+    for (ConcurrentTestThread t : testThreads_) {
+      t.join();
+    }
+    checkException();
+  }
+
+  public void waitFor(long millis) throws Exception {
+    long endTime = System.currentTimeMillis() + millis;
+    while (true) {
+      long left = endTime - System.currentTimeMillis();
+      if (left <= 0)
+
+        break;
+    }
+  }
+}

--- a/src/test/java/com/yahoo/sketches/concurrent/ConcurrentTestThread.java
+++ b/src/test/java/com/yahoo/sketches/concurrent/ConcurrentTestThread.java
@@ -1,0 +1,69 @@
+package com.yahoo.sketches.concurrent;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * @author eshcar
+ */
+public abstract class ConcurrentTestThread extends Thread{
+
+  private static final Log LOG = LogFactory.getLog(ConcurrentTestThread.class);
+
+  enum ThreadType {
+    MIXED, WRITER, READER
+  }
+
+  // protected final TestContext ctx_;
+  private AtomicBoolean stop_ = new AtomicBoolean(false);
+  private AtomicBoolean start_ = new AtomicBoolean(false);
+  ThreadType type_;
+
+  public ConcurrentTestThread(String type) {
+    type_ = ThreadType.valueOf(type);
+  }
+
+  public void run() {
+    int num = 1;
+
+    switch (type_) {
+    case WRITER:
+    	num = 10000000;
+    	break;
+    case READER:
+    	num = 10000;
+    	break;
+    case MIXED:
+    	num = 100000;
+    	break;
+    default:
+    	assert (false);
+    	break;
+    }
+
+    while (!start_.get()) {}
+
+    try {
+    	while (!stop_.get()) {  //TODO can impact performance!
+
+    		for (int i = 0; i < num; i++) {
+    			doWork();
+    		}
+    	}
+    } catch (Throwable t) {
+      LOG.info("catched RuntimeException: " + t);
+    }
+  }
+
+  public void stopThread() {
+    stop_.set(true);
+  }
+
+  public void startThread() {
+    start_.set(true);
+  }
+
+  public abstract void doWork() throws Exception;
+}

--- a/src/test/java/com/yahoo/sketches/theta/TestPerformanceTheta.java
+++ b/src/test/java/com/yahoo/sketches/theta/TestPerformanceTheta.java
@@ -1,0 +1,244 @@
+package com.yahoo.sketches.theta;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.yahoo.memory.WritableMemory;
+import com.yahoo.sketches.Family;
+import com.yahoo.sketches.concurrent.ConcurrentTestContext;
+import com.yahoo.sketches.concurrent.ConcurrentTestThread;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+/**
+ * @author eshcar
+ */
+public class TestPerformanceTheta {
+
+  private enum CONCURRENCY_TYPE {CONCURRENT, BASELINE, LOCK_BASED};
+  private static final String OFF_HEAP = "OFF-HEAP";
+  private static final int K = 512;
+
+  private UpdateSketch gadget_;
+  public final Log LOG = LogFactory.getLog(TestPerformanceTheta.class);
+
+  public static void main(String[] args) throws Exception {
+
+    TestPerformanceTheta test = new TestPerformanceTheta();
+
+    if(args.length<6) {
+      test.LOG.info("Missing arguemnts: java com.yahoo.sketches.concurrent.theta"
+          + ".TestPerformanceTheta <concurrencyType> <family> <#writers> <#readers> <seconds> "
+          + "<print>\n e.g., java "
+          + "com.yahoo.sketches.theta.TestPerformanceTheta CONCURRENT QUICKSELECT 4 4 "
+          + "30 true");
+      System.exit(0);
+    }
+
+    int i=0;
+    String concurrencyType = args[i++];
+    String family = args[i++];
+    int writers = Integer.parseInt(args[i++]);
+    int readers = Integer.parseInt(args[i++]);
+    int time = Integer.parseInt(args[i++]);
+    boolean print = Boolean.parseBoolean(args[i++]);
+
+    if (print) {
+      test.LOG.info("writers = " + writers);
+    }
+
+    test.setUp(concurrencyType, family);
+    test.runTest(CONCURRENCY_TYPE.valueOf(concurrencyType), writers, readers, time);
+
+    test.LOG.info("Done!");
+
+    System.exit(0);
+  }
+
+  public void setUp(String concurrencyType, String family) throws Exception {
+
+    WritableMemory mem;
+    UpdateSketch sketch;
+    UpdateSketch sketchToInit=null;
+    UpdateSketchBuilder usb = Sketches.updateSketchBuilder().setNominalEntries(K);
+    if(family.equalsIgnoreCase(OFF_HEAP)){
+      mem = WritableMemory.wrap(new byte[(K * 16) + 24]);
+      sketch = usb.build(mem);
+    } else {
+      sketch = usb.setFamily(Family.valueOf(family)).build();
+    }
+
+    switch (CONCURRENCY_TYPE.valueOf(concurrencyType)) {
+
+    case CONCURRENT:
+      if(family.equalsIgnoreCase(OFF_HEAP)){
+        gadget_ = ConcurrentThetaFactory.createConcurrentUpdateSketch(sketch);
+      } else {
+        gadget_ = ConcurrentThetaFactory.createConcurrentUpdateSketch(Family.valueOf(family));
+      }
+      sketchToInit = ConcurrentThetaFactory.createConcurrentThetaContext(
+          (ConcurrentUpdateSketch) gadget_);
+      LOG.info("=============================================CONCURRENT_THETA"
+          + "===========================================");
+      break;
+    case LOCK_BASED:
+      gadget_ = new LockBasedUpdateSketch(sketch);
+      sketchToInit = gadget_;
+      LOG.info("=============================================LOCK_BASED_THETA"
+          + "===========================================");
+      break;
+    case BASELINE:
+      gadget_ = sketch;
+      sketchToInit = sketch;
+      LOG.info("=============================================BASELINE_THETA"
+          + "===========================================");
+      break;
+    default:
+      String msg = concurrencyType + "is not a valid concurrency type, please choose "
+          + "CONCURRENT/LOCK_BASED/BASELINE";
+      LOG.info(msg);
+      throw new RuntimeException(msg);
+    }
+
+    for (long i = 0; i < 10000000; i++) {
+      sketchToInit.update(i);
+      if(i%100000==0){
+        System.out.print(".");
+      }
+    }
+    System.out.println();
+  }
+
+  private void runTest(CONCURRENCY_TYPE type, int writersNum, int readersNum, int secondsToRun)
+      throws
+      Exception {
+    LOG.info("start running");
+    ConcurrentTestContext ctx = new ConcurrentTestContext();
+
+    List<WriterThread> writersList = new ArrayList<>();
+    for (int i = 0; i < writersNum; i++) {
+      WriterThread writer = new WriterThread(type, i, writersNum);
+      writersList.add(writer);
+      ctx.addThread(writer);
+    }
+
+    List<ReaderThread> readersList = new ArrayList<>();
+    for (int i = 0; i < readersNum; i++) {
+      ReaderThread reader = new ReaderThread(type);
+      readersList.add(reader);
+      ctx.addThread(reader);
+    }
+
+    ctx.startThreads();
+    ctx.waitFor(secondsToRun * 1000);
+    ctx.stop();
+
+    long totalReads = 0;
+    long totalWrites = 0;
+
+    LOG.info("Write threads:");
+    for (WriterThread writer : writersList) {
+    	totalWrites += writer.operationsNum_;
+    }
+    LOG.info("writeTput = " + ((totalWrites / secondsToRun)) / 1000000 + " millions per second");
+
+    LOG.info("Read threads:");
+    for (ReaderThread reader : readersList) {
+    	totalReads += reader.readOperationsNum_;
+    }
+    LOG.info("readTput = " + ((totalReads / secondsToRun)) / 1000000 + "millions per second");
+
+    LOG.info("Estimation = " + gadget_.getEstimate());
+
+  }
+
+  public class WriterThread extends ConcurrentTestThread {
+    long operationsNum_ = 0;
+    private UpdateSketch context_;
+    int i_;
+    int jump_;
+
+    public WriterThread(CONCURRENCY_TYPE type, int id) {
+      this(type, id, 1);
+    }
+
+    public WriterThread(CONCURRENCY_TYPE type, int id, int jump) {
+    	super("WRITER");
+    	i_ = id;
+    	jump_ = jump;
+      switch (type) {
+      case CONCURRENT:
+        context_ = ConcurrentThetaFactory.createConcurrentThetaContext(
+            (ConcurrentUpdateSketch) gadget_);
+        break;
+      default:
+        context_ = gadget_;
+      }
+    }
+
+    @Override
+    public void doWork() throws Exception {
+
+    	context_.update(i_);
+    	operationsNum_++;
+    	i_ = i_ + jump_;
+    }
+  }
+
+  public class ReaderThread extends ConcurrentTestThread {
+
+    long readOperationsNum_ = 0;
+    private UpdateSketch context_;
+
+    public ReaderThread(CONCURRENCY_TYPE type) {
+      super("READER");
+      switch (type) {
+      case CONCURRENT:
+        context_ = ConcurrentThetaFactory.createConcurrentThetaContext(
+            (ConcurrentUpdateSketch) gadget_);
+        break;
+      default:
+        context_ = gadget_;
+      }
+
+    }
+
+    @Override
+    public void doWork() throws Exception {
+
+    	context_.getEstimate();
+    	readOperationsNum_++;
+    }
+  }
+
+  private static class LockBasedUpdateSketch extends UpdateSketchComposition {
+
+    private ReentrantReadWriteLock lock_;
+
+    protected LockBasedUpdateSketch(UpdateSketch delegatee) {
+      super(delegatee);
+      lock_ = new ReentrantReadWriteLock();
+    }
+
+    @Override public UpdateReturnState hashUpdate(long hash) {
+      try {
+        lock_.writeLock().lock();
+        return super.hashUpdate(hash);
+      } finally {
+        lock_.writeLock().unlock();
+      }
+
+    }
+
+    @Override public double getEstimate() {
+      try {
+        lock_.readLock().lock();
+        return super.getEstimate();
+      } finally {
+        lock_.readLock().unlock();
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
Moved your branch to a branch on sketches-core.

This is much cleaner!

You need to enable CheckStyle in your IDE and then point it to /tools/SketchesCheckstyle.xml

It should highlight public methods that are missing javadocs: namely: 
  ConcurrentThetaContext
  ConcurrentUpdateSketch

I already fixed a number of missing "final" modifiers.  

The current code has compile errors because of missing Logger.  However, I've decided to allow the single dependency: org.slf4j / slf4j-api.  This enables a user to pull in their own logger of choice at **runtime**, which can be the apache.commons.logging or the built in Java one or numerous other ones.  You can see how it is used in the Memory repository.  It adds virtually no overhead if you don't specify a logger at all.  Then when you attach your logger of choice, it pulls it in under a common interface.





