### PR TITLE
Numerous cleanup: Added unit tests for better coverage.

### DIFF
--- a/src/main/java/com/yahoo/sketches/theta/ConcurrentDirectQuickSelectSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/ConcurrentDirectQuickSelectSketch.java
@@ -104,7 +104,7 @@ class ConcurrentDirectQuickSelectSketch extends DirectQuickSelectSketch
   UpdateReturnState hashUpdate(final long hash) {
     final String msg = "No update method should be called directly to a shared theta sketch."
         + " Updating the shared sketch is only permitted through propagation from local sketches.";
-    throw new RuntimeException(msg);
+    throw new UnsupportedOperationException(msg);
   }
 
   //ConcurrentSharedThetaSketch declarations

--- a/src/main/java/com/yahoo/sketches/theta/ConcurrentHeapQuickSelectSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/ConcurrentHeapQuickSelectSketch.java
@@ -103,7 +103,7 @@ class ConcurrentHeapQuickSelectSketch extends HeapQuickSelectSketch
   UpdateReturnState hashUpdate(final long hash) {
     final String msg = "No update method should be called directly to a shared theta sketch."
         + " Updating the shared sketch is only permitted through propagation from local sketches.";
-    throw new RuntimeException(msg);
+    throw new UnsupportedOperationException(msg);
   }
 
   //ConcurrentSharedThetaSketch declarations

--- a/src/main/java/com/yahoo/sketches/theta/DirectQuickSelectSketchR.java
+++ b/src/main/java/com/yahoo/sketches/theta/DirectQuickSelectSketchR.java
@@ -113,16 +113,6 @@ class DirectQuickSelectSketchR extends UpdateSketch {
   }
 
   @Override
-  public HashIterator iterator() {
-    return new MemoryHashIterator(mem_, 1 << getLgArrLongs(), getThetaLong());
-  }
-
-  @Override
-  public ResizeFactor getResizeFactor() {
-    return ResizeFactor.getRF(getLgRF());
-  }
-
-  @Override
   public int getRetainedEntries(final boolean valid) { //always valid
     return mem_.getInt(RETAINED_ENTRIES_INT);
   }
@@ -153,6 +143,11 @@ class DirectQuickSelectSketchR extends UpdateSketch {
   }
 
   @Override
+  public HashIterator iterator() {
+    return new MemoryHashIterator(mem_, 1 << getLgArrLongs(), getThetaLong());
+  }
+
+  @Override
   public byte[] toByteArray() { //MY_FAMILY is stored in mem_
     final byte lgArrLongs = mem_.getByte(LG_ARR_LONGS_BYTE);
     final int preambleLongs = mem_.getByte(PREAMBLE_LONGS_BYTE) & 0X3F;
@@ -166,6 +161,16 @@ class DirectQuickSelectSketchR extends UpdateSketch {
   //UpdateSketch
 
   @Override
+  public int getLgNomLongs() {
+    return PreambleUtil.extractLgNomLongs(mem_);
+  }
+
+  @Override
+  public ResizeFactor getResizeFactor() {
+    return ResizeFactor.getRF(getLgRF());
+  }
+
+  @Override
   public UpdateSketch rebuild() {
     throw new SketchesReadOnlyException();
   }
@@ -173,11 +178,6 @@ class DirectQuickSelectSketchR extends UpdateSketch {
   @Override
   public void reset() {
     throw new SketchesReadOnlyException();
-  }
-
-  @Override
-  public int getLgNomLongs() {
-    return PreambleUtil.extractLgNomLongs(mem_);
   }
 
   //restricted methods
@@ -233,7 +233,7 @@ class DirectQuickSelectSketchR extends UpdateSketch {
     return mem_.getByte(LG_ARR_LONGS_BYTE) & 0XFF;
   }
 
-  int getLgRF() {
+  int getLgRF() { //only Direct needs this
     return (mem_.getByte(PREAMBLE_LONGS_BYTE) >>> LG_RESIZE_FACTOR_BIT) & 0X3;
   }
 

--- a/src/main/java/com/yahoo/sketches/theta/HeapQuickSelectSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapQuickSelectSketch.java
@@ -189,34 +189,29 @@ class HeapQuickSelectSketch extends HeapUpdateSketch {
   //restricted methods
 
   @Override
-  int getCurrentPreambleLongs(final boolean compact) {
-    if (!compact) { return preambleLongs_; }
-    return computeCompactPreLongs(thetaLong_, empty_, curCount_);
-  }
-
-  @Override
-  WritableMemory getMemory() {
-    return null;
-  }
-
-  @Override
   long[] getCache() {
     return cache_;
   }
 
   @Override
-  boolean isDirty() {
-    return false;
+  int getCurrentPreambleLongs(final boolean compact) {
+    if (!compact) { return preambleLongs_; }
+    return computeCompactPreLongs(thetaLong_, empty_, curCount_);
   }
 
-  @Override
-  boolean isOutOfSpace(final int numEntries) {
-    return numEntries > hashTableThreshold_;
+  //only used by ConcurrentHeapThetaBuffer & Test
+  int getHashTableThreshold() {
+    return hashTableThreshold_;
   }
 
   @Override
   int getLgArrLongs() {
     return lgArrLongs_;
+  }
+
+  @Override
+  WritableMemory getMemory() {
+    return null;
   }
 
   @Override
@@ -247,11 +242,16 @@ class HeapQuickSelectSketch extends HeapUpdateSketch {
       }
     }
     return InsertedCountIncremented;
-
   }
 
-  int getHashTableThreshold() {
-    return hashTableThreshold_;
+  @Override
+  boolean isDirty() {
+    return false;
+  }
+
+  @Override
+  boolean isOutOfSpace(final int numEntries) {
+    return numEntries > hashTableThreshold_;
   }
 
   //Must resize. Changes lgArrLongs_ and cache_. theta and count don't change.

--- a/src/main/java/com/yahoo/sketches/theta/HeapUpdateSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/HeapUpdateSketch.java
@@ -52,16 +52,6 @@ abstract class HeapUpdateSketch extends UpdateSketch {
   }
 
   @Override
-  public int getLgNomLongs() {
-    return lgNomLongs_;
-  }
-
-  @Override
-  public ResizeFactor getResizeFactor() {
-    return rf_;
-  }
-
-  @Override
   public boolean isDirect() {
     return false;
   }
@@ -69,6 +59,18 @@ abstract class HeapUpdateSketch extends UpdateSketch {
   @Override
   public boolean hasMemory() {
     return false;
+  }
+
+  //UpdateSketch
+
+  @Override
+  public int getLgNomLongs() {
+    return lgNomLongs_;
+  }
+
+  @Override
+  public ResizeFactor getResizeFactor() {
+    return rf_;
   }
 
   //restricted methods

--- a/src/main/java/com/yahoo/sketches/theta/UpdateSketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/UpdateSketch.java
@@ -115,9 +115,6 @@ public abstract class UpdateSketch extends Sketch {
   //Sketch interface
 
   @Override
-  public abstract boolean isEmpty();
-
-  @Override
   public boolean isCompact() {
     return false;
   }

--- a/src/main/java/com/yahoo/sketches/theta/UpdateSketchBuilder.java
+++ b/src/main/java/com/yahoo/sketches/theta/UpdateSketchBuilder.java
@@ -305,8 +305,29 @@ public class UpdateSketchBuilder {
     bMaxConcurrencyError = maxConcurrencyError;
   }
 
-  public void setbMaxNumLocalThreads(final int maxNumLocalThreads) {
+  /**
+   * Gets the Maximum Concurrency Error
+   * @return the Maximum Concurrency Error
+   */
+  public double getMaxConcurrencyError() {
+    return bMaxConcurrencyError;
+  }
+
+  /**
+   * Sets the Maximum Number of Local Threads.
+   * This is used to set the size of the local concurrent buffers.
+   * @param maxNumLocalThreads the given Maximum Number of Local Threads
+   */
+  public void setMaxNumLocalThreads(final int maxNumLocalThreads) {
     bMaxNumLocalThreads = maxNumLocalThreads;
+  }
+
+  /**
+   * Gets the Maximum Number of Local Threads.
+   * @return the Maximum Number of Local Threads.
+   */
+  public int getMaxNumLocalThreads() {
+    return bMaxNumLocalThreads;
   }
 
   // BUILD FUNCTIONS
@@ -401,8 +422,7 @@ public class UpdateSketchBuilder {
     return (UpdateSketch) buildSharedInternal(dstMem);
   }
 
-  //Also used in test
-  ConcurrentSharedThetaSketch buildSharedInternal(final WritableMemory dstMem) {
+  private ConcurrentSharedThetaSketch buildSharedInternal(final WritableMemory dstMem) {
     ConcurrentPropagationService.NUM_POOL_THREADS = bNumPoolThreads;
     if (dstMem == null) {
       return new ConcurrentHeapQuickSelectSketch(bLgNomLongs, bSeed, bMaxConcurrencyError);
@@ -426,18 +446,10 @@ public class UpdateSketchBuilder {
    */
   public UpdateSketch buildLocal(final UpdateSketch shared) {
     if ((shared == null) || !(shared instanceof ConcurrentSharedThetaSketch)) {
-      throw new SketchesStateException("The shared sketch must be built first.");
+      throw new SketchesStateException("The concurrent shared sketch must be built first.");
     }
-    return buildLocalInternal((ConcurrentSharedThetaSketch) shared);
-  }
-
-  //Also used in test
-  ConcurrentHeapThetaBuffer buildLocalInternal(final ConcurrentSharedThetaSketch shared) {
-    if (shared == null) {
-      throw new SketchesStateException("The shared sketch must be built first.");
-    }
-    return new ConcurrentHeapThetaBuffer(bLocalLgNomLongs, bSeed, shared,
-        bPropagateOrderedCompact, bMaxNumLocalThreads);
+    return new ConcurrentHeapThetaBuffer(bLocalLgNomLongs, bSeed,
+        (ConcurrentSharedThetaSketch) shared, bPropagateOrderedCompact, bMaxNumLocalThreads);
   }
 
   @Override


### PR DESCRIPTION
Eliminated buildLocalInternal in builder,
made buildSharedInternal private in builder
(this required numerous changes in the test code),
clarified sketch naming in tests,
added missing getters in builder,