### PR TITLE
Enable warnings for main tree, add suppress warnings for test tree.

### DIFF
--- a/src/main/java/com/yahoo/sketches/theta/Sketch.java
+++ b/src/main/java/com/yahoo/sketches/theta/Sketch.java
@@ -644,8 +644,6 @@ public abstract class Sketch {
 
   /**
    * Instantiates a Heap Sketch from Memory. SerVer 1 & 2 already handled.
-   * @param famID the Family ID
-   * @param ordered true if the sketch is of the Compact family and ordered
    * @param srcMem <a href="{@docRoot}/resources/dictionary.html#mem">See Memory</a>
    * @param seed <a href="{@docRoot}/resources/dictionary.html#seed">See Update Hash Seed</a>.
    * The seed required to instantiate a non-compact sketch.

--- a/src/main/java/com/yahoo/sketches/theta/UnionImpl.java
+++ b/src/main/java/com/yahoo/sketches/theta/UnionImpl.java
@@ -87,8 +87,8 @@ final class UnionImpl extends Union {
    */
   static UnionImpl initNewHeapInstance(final int lgNomLongs, final long seed, final float p,
       final ResizeFactor rf) {
-    final UpdateSketch gadget = new HeapQuickSelectSketch(
-        lgNomLongs, seed, p, rf, true); //create with UNION family
+    final UpdateSketch gadget = //create with UNION family
+        new HeapQuickSelectSketch(lgNomLongs, seed, p, rf, true);
     final UnionImpl unionImpl = new UnionImpl(gadget, seed);
     unionImpl.unionThetaLong_ = gadget.getThetaLong();
     unionImpl.unionEmpty_ = gadget.isEmpty();
@@ -114,8 +114,8 @@ final class UnionImpl extends Union {
       final ResizeFactor rf,
       final MemoryRequestServer memReqSvr,
       final WritableMemory dstMem) {
-    final UpdateSketch gadget = new DirectQuickSelectSketch(
-        lgNomLongs, seed, p, rf, memReqSvr, dstMem, true); //create with UNION family
+    final UpdateSketch gadget = //create with UNION family
+        new DirectQuickSelectSketch(lgNomLongs, seed, p, rf, memReqSvr, dstMem, true);
     final UnionImpl unionImpl = new UnionImpl(gadget, seed);
     unionImpl.unionThetaLong_ = gadget.getThetaLong();
     unionImpl.unionEmpty_ = gadget.isEmpty();

--- a/src/main/java/com/yahoo/sketches/tuple/adouble/DoubleSummaryDeserializer.java
+++ b/src/main/java/com/yahoo/sketches/tuple/adouble/DoubleSummaryDeserializer.java
@@ -23,6 +23,9 @@ import com.yahoo.memory.Memory;
 import com.yahoo.sketches.tuple.DeserializeResult;
 import com.yahoo.sketches.tuple.SummaryDeserializer;
 
+/**
+ * @author Lee Rhodes
+ */
 public class DoubleSummaryDeserializer implements SummaryDeserializer<DoubleSummary> {
 
   @Override

--- a/src/main/java/com/yahoo/sketches/tuple/strings/ArrayOfStringsSummary.java
+++ b/src/main/java/com/yahoo/sketches/tuple/strings/ArrayOfStringsSummary.java
@@ -34,7 +34,7 @@ import com.yahoo.sketches.tuple.UpdatableSummary;
  * @author Lee Rhodes
  */
 public class ArrayOfStringsSummary implements UpdatableSummary<String[]> {
-  public static final int PRIME = 0x7A3C_CA71;
+  private static final int PRIME = 0x7A3C_CA71;
   private String[] nodesArr = null;
 
   ArrayOfStringsSummary() { //required for ArrayOfStringsSummaryFactory
@@ -90,6 +90,9 @@ public class ArrayOfStringsSummary implements UpdatableSummary<String[]> {
     return nodes;
   }
 
+  /**
+   * @return the nodes array for this summary.
+   */
   public String[] getValue() {
     return nodesArr.clone();
   }
@@ -154,6 +157,10 @@ public class ArrayOfStringsSummary implements UpdatableSummary<String[]> {
     return XxHash64.hashChars(s.toCharArray(), 0, s.length(), PRIME);
   }
 
+  /**
+   * @param s the string to hash
+   * @return the hash of the string
+   */
   public static long stringHash(final String s) {
     return XxHash64.hashChars(s.toCharArray(), 0, s.length(), PRIME);
   }

--- a/src/test/java/com/yahoo/sketches/BinomialBoundsNTest.java
+++ b/src/test/java/com/yahoo/sketches/BinomialBoundsNTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 /**
  * @author Kevin Lang
  */
+@SuppressWarnings("javadoc")
 public class BinomialBoundsNTest {
 
   public static double[] runTestAux (long max_numSamplesI, int ci, double min_p) {
@@ -41,21 +42,21 @@ public class BinomialBoundsNTest {
     double sum3 = 0.0;
     double sum4 = 0.0;
     long count = 0;
-  
+
     while (numSamplesI <= max_numSamplesI) { /* was <= */
       p = 1.0;
-      
+
       while (p >= min_p) {
         lb = BinomialBoundsN.getLowerBound (numSamplesI, p, ci, false);
         ub = BinomialBoundsN.getUpperBound (numSamplesI, p, ci, false);
-        
+
         // if (numSamplesI == 300 && p > 0.365 && p < 0.367) { ub += 0.01; }  // artificial discrepancy
-        
+
         // the logarithm helps discrepancies to not be swamped out of the total
-        sum1 += Math.log (lb + 1.0); 
+        sum1 += Math.log (lb + 1.0);
         sum2 += Math.log (ub + 1.0);
         count += 2;
-        
+
         if (p < 1.0) {
           lb = BinomialBoundsN.getLowerBound (numSamplesI, 1.0 - p, ci, false);
           ub = BinomialBoundsN.getUpperBound (numSamplesI, 1.0 - p, ci, false);
@@ -63,32 +64,32 @@ public class BinomialBoundsNTest {
           sum4 += Math.log (ub + 1.0);
           count += 2;
         }
-        
+
         p *= 0.99;
       }
-      numSamplesI = Math.max (numSamplesI+1, 1001*numSamplesI/1000);
+      numSamplesI = Math.max (numSamplesI+1, (1001*numSamplesI)/1000);
     }
-    
+
     println(String.format("{%.15e, %.15e, %.15e, %.15e, %d}", sum1, sum2, sum3, sum4, count));
     double[] arrOut = {sum1, sum2, sum3, sum4, count};
     return arrOut;
   }
-  
+
   private static final double TOL = 1E-15;
-  
+
   @Test
   public static void checkBounds() {
     int i = 0;
     for (int ci = 1; ci <= 3; ci++, i++) {
       double[] arr = runTestAux (20, ci, 1e-3);
       for (int j=0; j<5; j++) {
-        assertTrue((arr[j] / std[i][j] -1.0) < TOL);
+        assertTrue(((arr[j] / std[i][j]) -1.0) < TOL);
       }
     }
     for (int ci = 1; ci <= 3; ci++, i++) {
       double[] arr = runTestAux (200, ci, 1e-5);
       for (int j=0; j<5; j++) {
-        assertTrue((arr[j] / std[i][j] -1.0) < TOL);
+        assertTrue(((arr[j] / std[i][j]) -1.0) < TOL);
       }
     }
     //comment last one out for a shorter test
@@ -99,22 +100,22 @@ public class BinomialBoundsNTest {
 //      }
 //    }
   }
-  
+
   // With all 3 enabled the test should produce in groups of 3 */
   private static final double[][] std = {
     {7.083330682531043e+04, 8.530373642825481e+04, 3.273647725073409e+04, 3.734024243699785e+04, 57750},
     {6.539415269641498e+04, 8.945522372568645e+04, 3.222302546497840e+04, 3.904738469737429e+04, 57750},
     {6.006043493107306e+04, 9.318105731423477e+04, 3.186269956585285e+04, 4.096466221922520e+04, 57750},
-    
+
     {2.275584770163813e+06, 2.347586549014998e+06, 1.020399409477305e+06, 1.036729927598294e+06, 920982},
     {2.243569126699713e+06, 2.374663344107342e+06, 1.017017233582122e+06, 1.042597845553438e+06, 920982},
     {2.210056231903739e+06, 2.400441267999687e+06, 1.014081235946986e+06, 1.049480769755676e+06, 920982},
-    
+
     {4.688240115809608e+07, 4.718067204619278e+07, 2.148362024482338e+07, 2.153118905212302e+07, 12834414},
     {4.674205938540214e+07, 4.731333757486791e+07, 2.146902141966406e+07, 2.154916650733873e+07, 12834414},
     {4.659896614422579e+07, 4.744404182094614e+07, 2.145525391547799e+07, 2.156815612325058e+07, 12834414}
   };
-  
+
   @Test
   public static void checkCheckArgs() {
     try {
@@ -129,7 +130,7 @@ public class BinomialBoundsNTest {
       //pass
     }
   }
-  
+
   @Test
   public static void checkComputeApproxBino_LB_UB() {
     long n = 100;
@@ -143,12 +144,12 @@ public class BinomialBoundsNTest {
     result = getUpperBound(n, theta, 1, true);
     assertEquals(result, 0.0, 0.0);
   }
-  
+
   @Test(expectedExceptions = SketchesArgumentException.class)
   public static void checkThetaLimits1() {
     BinomialBoundsN.getUpperBound(100, 1.1, 1, false);
   }
-  
+
   @Test
   public static void boundsExample() {
     println("BinomialBoundsN Example:");
@@ -164,17 +165,17 @@ public class BinomialBoundsNTest {
     println("LB:  "+lb);
     println("");
   }
-  
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/BoundsOnBinomialProportionsTest.java
+++ b/src/test/java/com/yahoo/sketches/BoundsOnBinomialProportionsTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Kevin Lang
  */
+@SuppressWarnings("javadoc")
 public class BoundsOnBinomialProportionsTest {
 
   @Test
@@ -51,7 +52,7 @@ public class BoundsOnBinomialProportionsTest {
       //      System.out.printf ("LB\t%d\t%d\t%.1f\t%.16g%n", n, k, kappa, lb);
     }
   }
-  
+
   @Test
   public static void tinyUBTest () {
     // these answers were computed using a different programming language and therefore might not match exactly.
@@ -68,7 +69,7 @@ public class BoundsOnBinomialProportionsTest {
       //      System.out.printf ("UB\t%d\t%d\t%.1f\t%.16g%n", n, k, kappa, ub);
     }
   }
-  
+
   // This is for Kevin's use only, and will not be one of the unit tests.
   public static void lotsOfSpewage (long maxN) {
     for (long n = 0; n <= maxN; n++) {
@@ -113,7 +114,7 @@ public class BoundsOnBinomialProportionsTest {
     println("LB: "+lb);
     println("UB: "+ub);
   }
-  
+
   @Test
   public static void checkInputs() {
     try {
@@ -139,24 +140,24 @@ public class BoundsOnBinomialProportionsTest {
     }
     assertEquals(estimateUnknownP(0, 0), 0.5, 0.0);
   }
-  
+
   @Test
   public static void checkErf() {
     assertTrue(erf(-2.0) < 0.99);
     assertTrue(erf(2.0)  > 0.99);
   }
-  
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here
   }
-  
-  
+
+
 }

--- a/src/test/java/com/yahoo/sketches/BoundsOnRatiosInSampledSetsTest.java
+++ b/src/test/java/com/yahoo/sketches/BoundsOnRatiosInSampledSetsTest.java
@@ -29,6 +29,7 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class BoundsOnRatiosInSampledSetsTest {
 
   @Test
@@ -37,31 +38,31 @@ public class BoundsOnRatiosInSampledSetsTest {
     getLowerBoundForBoverA(500, 100, 0.75);
     getLowerBoundForBoverA(500, 100, 1.0);
     assertEquals(getLowerBoundForBoverA(0, 0, .1), 0.0, 0.0);
-    
+
     getUpperBoundForBoverA(500, 100, .1);
     getUpperBoundForBoverA(500, 100, 0.75);
     getUpperBoundForBoverA(500, 100, 1.0);
     assertEquals(getUpperBoundForBoverA(0, 0, .1), 1.0, 0.0);
-    
+
     getEstimateOfBoverA(500,100);
     getEstimateOfA(500, .1);
     getEstimateOfB(100, .1);
     assertEquals(getEstimateOfBoverA(0, 0), .5, 0.0);
   }
-  
+
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkInputA() {
     checkInputs(-1, 0, .3);
   }
-  
+
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkInputB() {
     checkInputs(500, -1, .3);
   }
-  
+
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkInputF() {
     checkInputs(500, 100, -1);
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/BoundsOnRatiosInThetaSketchedSetsTest.java
+++ b/src/test/java/com/yahoo/sketches/BoundsOnRatiosInThetaSketchedSetsTest.java
@@ -29,6 +29,7 @@ import com.yahoo.sketches.theta.Intersection;
 import com.yahoo.sketches.theta.Sketches;
 import com.yahoo.sketches.theta.UpdateSketch;
 
+@SuppressWarnings("javadoc")
 public class BoundsOnRatiosInThetaSketchedSetsTest {
 
   @Test
@@ -38,7 +39,7 @@ public class BoundsOnRatiosInThetaSketchedSetsTest {
     int uA = 10000;
     int uC = 100000;
     for (int i=0; i<uA; i++) { skA.update(i); }
-    for (int i=0; i<uC; i++) { skC.update(i+uA/2); }
+    for (int i=0; i<uC; i++) { skC.update(i+(uA/2)); }
     Intersection inter = Sketches.setOperationBuilder().buildIntersection();
     inter.update(skA);
     inter.update(skC);
@@ -76,7 +77,7 @@ public class BoundsOnRatiosInThetaSketchedSetsTest {
     int uA = 100000;
     int uC = 10000;
     for (int i=0; i<uA; i++) { skA.update(i); }
-    for (int i=0; i<uC; i++) { skC.update(i+uA/2); }
+    for (int i=0; i<uC; i++) { skC.update(i+(uA/2)); }
     BoundsOnRatiosInThetaSketchedSets.getEstimateOfBoverA(skA, skC);
   }
 
@@ -86,7 +87,7 @@ public class BoundsOnRatiosInThetaSketchedSetsTest {
   }
 
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here

--- a/src/test/java/com/yahoo/sketches/ByteArrayUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/ByteArrayUtilTest.java
@@ -46,6 +46,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class ByteArrayUtilTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/FamilyTest.java
+++ b/src/test/java/com/yahoo/sketches/FamilyTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class FamilyTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/HashOperationsTest.java
+++ b/src/test/java/com/yahoo/sketches/HashOperationsTest.java
@@ -38,6 +38,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class HashOperationsTest {
 
   //Not otherwise already covered

--- a/src/test/java/com/yahoo/sketches/QuickSelectTest.java
+++ b/src/test/java/com/yahoo/sketches/QuickSelectTest.java
@@ -32,12 +32,13 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class QuickSelectTest {
   private static final String LS = System.getProperty("line.separator");
   private static final Random random = new Random(); // pseudo-random number generator
 
   //long[] arrays
-  
+
   @Test
   public void checkQuickSelect0Based() {
     int len = 64;
@@ -98,9 +99,9 @@ public class QuickSelectTest {
     long retVal = selectIncludingZeros(arr, pivot);
     Assert.assertEquals(retVal, trueVal);
   }
-  
+
   //double[] arrays
-  
+
   @Test
   public void checkQuickSelectDbl0Based() {
     int len = 64;
@@ -161,7 +162,7 @@ public class QuickSelectTest {
     double retVal = selectIncludingZeros(arr, pivot);
     Assert.assertEquals(retVal, trueVal, 0.0);
   }
-  
+
 
   /**
    * Rearrange the elements of an array in random order.
@@ -190,11 +191,11 @@ public class QuickSelectTest {
       a[r] = temp;
     }
   }
-  
-  
+
+
   /**
    * Returns an integer uniformly between 0 (inclusive) and n (exclusive) where {@code n > 0}
-   * 
+   *
    * @param n the upper exclusive bound
    * @return random integer
    */
@@ -228,7 +229,7 @@ public class QuickSelectTest {
     }
     return sb.toString();
   }
-  
+
   //For console testing
   static void test1() {
     int len = 16;
@@ -285,7 +286,7 @@ public class QuickSelectTest {
     println(printArr(arr));
   }
 
-  //For console testing    
+  //For console testing
   static void test3() {
     int len = 16;
     int nonZeros = (3 * len) / 4;
@@ -368,7 +369,7 @@ public class QuickSelectTest {
     println(printArr(arr));
   }
 
-  //For console testing    
+  //For console testing
   static void testDbl3() {
     int len = 16;
     int nonZeros = (3 * len) / 4;
@@ -395,7 +396,7 @@ public class QuickSelectTest {
     println("Result Array:"+LS);
     println(printArr(arr));
   }
-  
+
 //  public static void main(String[] args) {
 //    println(LS+"==LONGS 1=========="+LS);
 //    test1();
@@ -409,7 +410,7 @@ public class QuickSelectTest {
 //    testDbl2();
 //    println(LS+"==DOUBLES 3========"+LS);
 //    testDbl3();
-//    
+//
 //
 //    QuickSelectTest qst = new QuickSelectTest();
 //    qst.checkQuickSelect0Based();
@@ -422,24 +423,24 @@ public class QuickSelectTest {
 //    qst.checkQuickSelectDbl1BasedIncludingZeros();
 //
 //  }
-  
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here
   }
-  
+
   /**
-   * @param d value to print 
+   * @param d value to print
    */
   static void println(double d) {
     //System.out.println(d); //disable here
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/SketchesExceptionTest.java
+++ b/src/test/java/com/yahoo/sketches/SketchesExceptionTest.java
@@ -21,6 +21,7 @@ package com.yahoo.sketches;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class SketchesExceptionTest {
 
   @Test(expectedExceptions = SketchesException.class)

--- a/src/test/java/com/yahoo/sketches/UtilTest.java
+++ b/src/test/java/com/yahoo/sketches/UtilTest.java
@@ -51,6 +51,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class UtilTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/com/yahoo/sketches/cpc/CompressedStateTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CompressedStateTest.java
@@ -32,6 +32,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CompressedStateTest {
   static PrintStream ps = System.out;
   long vIn = 0;

--- a/src/test/java/com/yahoo/sketches/cpc/CompressionCharacterization.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CompressionCharacterization.java
@@ -37,6 +37,7 @@ import com.yahoo.memory.WritableMemory;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
+@SuppressWarnings("javadoc")
 public class CompressionCharacterization {
   private String hfmt;
   private String dfmt;

--- a/src/test/java/com/yahoo/sketches/cpc/CompressionDataTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CompressionDataTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CompressionDataTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/cpc/CpcCBinariesTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CpcCBinariesTest.java
@@ -34,6 +34,7 @@ import com.yahoo.memory.Memory;
  * Checks sketch images obtained from C++.
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CpcCBinariesTest {
   static PrintStream ps = System.out;
   static final String LS = System.getProperty("line.separator");

--- a/src/test/java/com/yahoo/sketches/cpc/CpcCompressionTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CpcCompressionTest.java
@@ -43,6 +43,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CpcCompressionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/cpc/CpcSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CpcSketchTest.java
@@ -36,6 +36,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CpcSketchTest {
   static PrintStream ps = System.out;
 

--- a/src/test/java/com/yahoo/sketches/cpc/CpcUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CpcUnionTest.java
@@ -32,6 +32,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CpcUnionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/cpc/CpcWrapperTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/CpcWrapperTest.java
@@ -32,6 +32,7 @@ import com.yahoo.sketches.Family;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CpcWrapperTest {
   static PrintStream ps = System.out;
 

--- a/src/test/java/com/yahoo/sketches/cpc/IconEstimatorTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/IconEstimatorTest.java
@@ -30,6 +30,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class IconEstimatorTest {
 
   //SLOW EXACT VERSION, Eventually move to characterization

--- a/src/test/java/com/yahoo/sketches/cpc/LzTzSpeedTesting.java
+++ b/src/test/java/com/yahoo/sketches/cpc/LzTzSpeedTesting.java
@@ -33,6 +33,7 @@ import java.util.Random;
  *
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class LzTzSpeedTesting {
   static final byte[] byteTrailingZerosTable = new byte[256];
   static final byte[] byteLeadingZerosTable = new byte[256];

--- a/src/test/java/com/yahoo/sketches/cpc/MergingValidation.java
+++ b/src/test/java/com/yahoo/sketches/cpc/MergingValidation.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
+@SuppressWarnings("javadoc")
 public class MergingValidation {
   private String hfmt;
   private String dfmt;

--- a/src/test/java/com/yahoo/sketches/cpc/PairTableTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/PairTableTest.java
@@ -32,6 +32,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class PairTableTest {
   Random rand = new Random();
 

--- a/src/test/java/com/yahoo/sketches/cpc/PreambleUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/PreambleUtilTest.java
@@ -64,6 +64,7 @@ import com.yahoo.sketches.cpc.PreambleUtil.HiField;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
   static final short defaultSeedHash = computeSeedHash(DEFAULT_UPDATE_SEED) ;
 

--- a/src/test/java/com/yahoo/sketches/cpc/QuickMergingValidation.java
+++ b/src/test/java/com/yahoo/sketches/cpc/QuickMergingValidation.java
@@ -32,6 +32,7 @@ import java.io.PrintWriter;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
+@SuppressWarnings("javadoc")
 public class QuickMergingValidation {
   private String hfmt;
   private String dfmt;

--- a/src/test/java/com/yahoo/sketches/cpc/RuntimeAssertsTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/RuntimeAssertsTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class RuntimeAssertsTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/cpc/SpecialCBinariesTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/SpecialCBinariesTest.java
@@ -38,6 +38,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class SpecialCBinariesTest {
   static PrintStream ps = System.out;
   static final String LS = System.getProperty("line.separator");

--- a/src/test/java/com/yahoo/sketches/cpc/StreamingValidation.java
+++ b/src/test/java/com/yahoo/sketches/cpc/StreamingValidation.java
@@ -30,6 +30,7 @@ import java.io.PrintWriter;
  * @author Lee Rhodes
  * @author Kevin Lang
  */
+@SuppressWarnings("javadoc")
 public class StreamingValidation {
   private String hfmt;
   private String dfmt;

--- a/src/test/java/com/yahoo/sketches/cpc/TestAllTest.java
+++ b/src/test/java/com/yahoo/sketches/cpc/TestAllTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class TestAllTest {
 
   //STREAMING

--- a/src/test/java/com/yahoo/sketches/fdt/FdtSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/fdt/FdtSketchTest.java
@@ -35,6 +35,7 @@ import com.yahoo.sketches.tuple.strings.ArrayOfStringsSummary;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class FdtSketchTest {
   private static final String LS = System.getProperty("line.separator");
   private static final char sep = '|'; //string separator

--- a/src/test/java/com/yahoo/sketches/fdt/GroupTest.java
+++ b/src/test/java/com/yahoo/sketches/fdt/GroupTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class GroupTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/com/yahoo/sketches/frequencies/DistTest.java
+++ b/src/test/java/com/yahoo/sketches/frequencies/DistTest.java
@@ -22,6 +22,7 @@ package com.yahoo.sketches.frequencies;
 import org.testng.Assert;
 //import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class DistTest {
 
   /**
@@ -29,7 +30,7 @@ public class DistTest {
    * @return a random number generated from the geometric distribution.
    */
   public static long randomGeometricDist(double prob) {
-    assert (prob > 0.0 && prob < 1.0);
+    assert ((prob > 0.0) && (prob < 1.0));
     return 1 + (long) (Math.log(Math.random()) / Math.log(1.0 - prob));
   }
 
@@ -40,8 +41,9 @@ public class DistTest {
     int i;
     double ans = 0.0;
 
-    for (i = 1; i <= n; i++)
+    for (i = 1; i <= n; i++) {
       ans += Math.pow(1. / i, theta);
+    }
     return (ans);
   }
 
@@ -60,18 +62,20 @@ public class DistTest {
     // the first time since it uses the random generators
 
     alpha = 1. / (1. - theta);
-    eta = (1. - Math.pow(2. / n, 1. - theta)) / (1. - zeta(2, theta) / zetan);
+    eta = (1. - Math.pow(2. / n, 1. - theta)) / (1. - (zeta(2, theta) / zetan));
 
     u = 0.0;
-    while (u == 0.0)
+    while (u == 0.0) {
       u = Math.random();
+    }
     uz = u * zetan;
-    if (uz < 1.)
+    if (uz < 1.) {
       val = 1;
-    else if (uz < (1. + Math.pow(0.5, theta)))
+    } else if (uz < (1. + Math.pow(0.5, theta))) {
       val = 2;
-    else
-      val = 1 + (n * Math.pow(eta * u - eta + 1., alpha));
+    } else {
+      val = 1 + (n * Math.pow(((eta * u) - eta) + 1., alpha));
+    }
 
     return (long) val;
   }
@@ -82,11 +86,12 @@ public class DistTest {
     double prob = .1;
     for (int i = 0; i < 100; i++) {
       long item = randomGeometricDist(prob);
-      if (item > maxItem)
+      if (item > maxItem) {
         maxItem = item;
+      }
       // If you succeed with probability p the probability
       // of failing 20/p times is smaller than 1/2^20.
-      Assert.assertTrue(maxItem < 20.0 / prob);
+      Assert.assertTrue(maxItem < (20.0 / prob));
     }
   }
 

--- a/src/test/java/com/yahoo/sketches/frequencies/ItemsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/frequencies/ItemsSketchTest.java
@@ -41,6 +41,7 @@ import com.yahoo.sketches.ArrayOfUtf16StringsSerDe;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.frequencies.ItemsSketch.Row;
 
+@SuppressWarnings("javadoc")
 public class ItemsSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/frequencies/LongsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/frequencies/LongsSketchTest.java
@@ -41,6 +41,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.Util;
 import com.yahoo.sketches.frequencies.LongsSketch.Row;
 
+@SuppressWarnings("javadoc")
 public class LongsSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/frequencies/ReversePurgeLongHashMapTest.java
+++ b/src/test/java/com/yahoo/sketches/frequencies/ReversePurgeLongHashMapTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ReversePurgeLongHashMapTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/com/yahoo/sketches/frequencies/SerDeCompatibilityTest.java
+++ b/src/test/java/com/yahoo/sketches/frequencies/SerDeCompatibilityTest.java
@@ -26,13 +26,14 @@ import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.ArrayOfItemsSerDe;
 import com.yahoo.sketches.ArrayOfLongsSerDe;
 
+@SuppressWarnings("javadoc")
 public class SerDeCompatibilityTest {
 
   static final ArrayOfItemsSerDe<Long> serDe = new ArrayOfLongsSerDe();
 
   @Test
   public void itemsToLongs() {
-    ItemsSketch<Long> sketch1 = new ItemsSketch<Long>(8);
+    ItemsSketch<Long> sketch1 = new ItemsSketch<>(8);
     sketch1.update(1L);
     sketch1.update(2L);
     sketch1.update(3L);

--- a/src/test/java/com/yahoo/sketches/frequencies/StressTestHashMap.java
+++ b/src/test/java/com/yahoo/sketches/frequencies/StressTestHashMap.java
@@ -21,14 +21,15 @@ package com.yahoo.sketches.frequencies;
 
 import com.yahoo.sketches.hash.MurmurHash3;
 
+@SuppressWarnings("javadoc")
 public class StressTestHashMap {
 
   public static void main(String[] args) {
     stress();
   }
-  
+
   private static void stress() {
-    for (int capacity = 2 << 5; capacity < 2 << 24; capacity *= 2) {
+    for (int capacity = 2 << 5; capacity < (2 << 24); capacity *= 2) {
       int n = 10000000;
 
       long[] keys = new long[n];
@@ -36,7 +37,7 @@ public class StressTestHashMap {
 
       for (int i = 0; i < n; i++) {
         keys[i] = murmur(i);
-        values[i] = (i < capacity / 2) ? n : 1;
+        values[i] = (i < (capacity / 2)) ? n : 1;
       }
 
       ReversePurgeLongHashMap hashmap = new ReversePurgeLongHashMap(capacity);

--- a/src/test/java/com/yahoo/sketches/hash/MurmurHash3AdaptorTest.java
+++ b/src/test/java/com/yahoo/sketches/hash/MurmurHash3AdaptorTest.java
@@ -33,6 +33,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class MurmurHash3AdaptorTest {
 
   @Test
@@ -90,7 +91,7 @@ public class MurmurHash3AdaptorTest {
     result = hashToBytes(arr, 0L);
     Assert.assertEquals(result, null);
   }
-  
+
   @Test
   public void checkToBytesByteArr() {
     byte[] arr = { 1, 2 };
@@ -195,7 +196,7 @@ public class MurmurHash3AdaptorTest {
     result = hashToLongs(arr, 0L);
     Assert.assertEquals(result, null);
   }
-  
+
   @Test
   public void checkToLongsByteArr() {
     byte[] arr = { 1, 2 };
@@ -265,8 +266,8 @@ public class MurmurHash3AdaptorTest {
   }
 
   //Check asInt() functions
-  
-  @Test 
+
+  @Test
   public void checkAsInt() {
     int lo = (3 << 28);
     int hi = (1 << 30) + 1;
@@ -276,31 +277,31 @@ public class MurmurHash3AdaptorTest {
       Assert.assertTrue((result >= 0) && (result < lo));
       result = asInt(longArr, hi);
       Assert.assertTrue((result >= 0) && (result < hi));
-      
+
       int[] intArr = {i, i+1};           //int[]
       result = asInt(intArr, lo);
       Assert.assertTrue((result >= 0) && (result < lo));
       result = asInt(intArr, hi);
       Assert.assertTrue((result >= 0) && (result < hi));
-      
+
       byte[] byteArr = {i, (byte)(i+1)}; //byte[]
       result = asInt(byteArr, lo);
       Assert.assertTrue((result >= 0) && (result < lo));
       result = asInt(byteArr, hi);
       Assert.assertTrue((result >= 0) && (result < hi));
-      
+
       long longV = i;                    //long
       result = asInt(longV, lo);
       Assert.assertTrue((result >= 0) && (result < lo));
       result = asInt(longV, hi);
       Assert.assertTrue((result >= 0) && (result < hi));
-      
+
       double v = i;                //double
       result = asInt(v, lo);
       Assert.assertTrue((result >= 0) && (result < lo));
       result = asInt(v, hi);
       Assert.assertTrue((result >= 0) && (result < hi));
-      
+
       String s = Integer.toString(i);    //String
       result = asInt(s, lo);
       Assert.assertTrue((result >= 0) && (result < lo));
@@ -308,37 +309,37 @@ public class MurmurHash3AdaptorTest {
       Assert.assertTrue((result >= 0) && (result < hi));
     }
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseLongNull() {
     long[] arr = null;
     asInt(arr, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseLongEmpty() {
     long[] arr = new long[0];
     asInt(arr, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseIntNull() {
     int[] arr = null;
     asInt(arr, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseIntEmpty() {
     int[] arr = new int[0];
     asInt(arr, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseByteNull() {
     byte[] arr = null;
     asInt(arr, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseByteEmpty() {
     byte[] arr = new byte[0];
@@ -350,26 +351,26 @@ public class MurmurHash3AdaptorTest {
     String s = null;
     asInt(s, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseStringEmpty() {
     String s = "";
     asInt(s, 1000);
   }
-  
+
   @Test (expectedExceptions = SketchesArgumentException.class)
   public void checkAsIntCornerCaseNTooSmall() {
     String s = "abc";
     asInt(s, 1);
   }
-  
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here

--- a/src/test/java/com/yahoo/sketches/hash/MurmurHash3Test.java
+++ b/src/test/java/com/yahoo/sketches/hash/MurmurHash3Test.java
@@ -28,9 +28,10 @@ import org.testng.annotations.Test;
 /**
  * Tests the MurmurHash3 against specific, known hash results given known
  * inputs obtained from the public domain C++ version 150.
- * 
+ *
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class MurmurHash3Test {
 
   @Test
@@ -124,8 +125,8 @@ public class MurmurHash3Test {
     Assert.assertEquals(result[0], h1);
     Assert.assertEquals(result[1], h2);
   }
-  
-  
+
+
   /**
    * Tests an odd remainder of int[].
    */
@@ -156,7 +157,7 @@ public class MurmurHash3Test {
     Assert.assertEquals(result[0], h1);
     Assert.assertEquals(result[1], h2);
   }
-  
+
   /**
    * Tests an odd remainder of int[].
    */
@@ -171,14 +172,14 @@ public class MurmurHash3Test {
     Assert.assertEquals(result[0], h1);
     Assert.assertEquals(result[1], h2);
   }
-  
+
   @Test
   public void checkByteArrAllOnesZeros() { //byte[], test a ones byte and a zeros byte
-    byte[] key = { 
+    byte[] key = {
       0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69, 0x63, 0x6b, 0x20, 0x62, 0x72, 0x6f, 0x77, 0x6e,
       0x20, 0x66, 0x6f, 0x78, 0x20, 0x6a, 0x75, 0x6d, 0x70, 0x73, 0x20, 0x6f, 0x76, 0x65,
       0x72, 0x20, 0x74, 0x68, 0x65, 0x20, 0x6c, 0x61, 0x7a, 0x79, 0x20, 0x64, 0x6f, 0x67,
-      (byte) 0xff, 0x64, 0x6f, 0x67, 0x00 
+      (byte) 0xff, 0x64, 0x6f, 0x67, 0x00
     };
     long[] result = MurmurHash3.hash(key, 0);
 
@@ -202,22 +203,22 @@ public class MurmurHash3Test {
     long[] out1 = hash(bArr, 0L);
     println(com.yahoo.sketches.Util.longToHexBytes(out1[0]));
     println(com.yahoo.sketches.Util.longToHexBytes(out1[1]));
-    
+
     println("Chars");
-    char[] cArr = {0X0201, 0X0403, 0X0605, 0X0807,   0X0a09, 0X0c0b, 0X0e0d, 0X100f, 
+    char[] cArr = {0X0201, 0X0403, 0X0605, 0X0807,   0X0a09, 0X0c0b, 0X0e0d, 0X100f,
         0X1211, 0X1413, 0X1615, 0X1817};
     out = hash(cArr, 0L);
     Assert.assertEquals(out, out1);
     println(com.yahoo.sketches.Util.longToHexBytes(out[0]));
     println(com.yahoo.sketches.Util.longToHexBytes(out[1]));
-    
+
     println("Ints");
     int[] iArr = {0X04030201, 0X08070605,   0X0c0b0a09, 0X100f0e0d,   0X14131211,   0X18171615};
     out = hash(iArr, 0L);
     Assert.assertEquals(out, out1);
     println(com.yahoo.sketches.Util.longToHexBytes(out[0]));
     println(com.yahoo.sketches.Util.longToHexBytes(out[1]));
-    
+
     println("Longs");
     long[] lArr = {0X0807060504030201L, 0X100f0e0d0c0b0a09L, 0X1817161514131211L};
     out = hash(lArr, 0L);
@@ -225,8 +226,8 @@ public class MurmurHash3Test {
     println(com.yahoo.sketches.Util.longToHexBytes(out[0]));
     println(com.yahoo.sketches.Util.longToHexBytes(out[1]));
   }
-  
-  
+
+
   //Helper methods
   private static long[] stringToLongs(String in) {
     byte[] bArr = in.getBytes(UTF_8);
@@ -270,9 +271,9 @@ public class MurmurHash3Test {
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //disable here

--- a/src/test/java/com/yahoo/sketches/hash/MurmurHash3v2Test.java
+++ b/src/test/java/com/yahoo/sketches/hash/MurmurHash3v2Test.java
@@ -30,6 +30,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class MurmurHash3v2Test {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hash/XxHashTest.java
+++ b/src/test/java/com/yahoo/sketches/hash/XxHashTest.java
@@ -28,6 +28,7 @@ import com.yahoo.memory.Memory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class XxHashTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/AuxHashMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/AuxHashMapTest.java
@@ -30,6 +30,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class AuxHashMapTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/com/yahoo/sketches/hll/BaseHllSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/BaseHllSketchTest.java
@@ -30,6 +30,7 @@ import com.yahoo.memory.WritableMemory;
  * @author Lee Rhodes
  *
  */
+@SuppressWarnings("javadoc")
 public class BaseHllSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/CouponListTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/CouponListTest.java
@@ -31,6 +31,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CouponListTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/CrossCountingTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/CrossCountingTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "javadoc"})
 public class CrossCountingTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/com/yahoo/sketches/hll/DirectAuxHashMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/DirectAuxHashMapTest.java
@@ -39,6 +39,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectAuxHashMapTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/DirectCouponListTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/DirectCouponListTest.java
@@ -34,6 +34,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectCouponListTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/DirectHllSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/DirectHllSketchTest.java
@@ -34,6 +34,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectHllSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/DirectUnionCaseTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/DirectUnionCaseTest.java
@@ -36,6 +36,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectUnionCaseTest {
   long v = 0;
 

--- a/src/test/java/com/yahoo/sketches/hll/DirectUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/DirectUnionTest.java
@@ -37,6 +37,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectUnionTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/com/yahoo/sketches/hll/HllArrayTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/HllArrayTest.java
@@ -29,8 +29,8 @@ import com.yahoo.memory.WritableMemory;
 
 /**
  * @author Lee Rhodes
- *
  */
+@SuppressWarnings("javadoc")
 public class HllArrayTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/HllSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/HllSketchTest.java
@@ -44,7 +44,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
-//@SuppressWarnings("unused")
+@SuppressWarnings("javadoc")
 public class HllSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/PreambleUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/PreambleUtilTest.java
@@ -40,6 +40,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/TablesTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/TablesTest.java
@@ -28,10 +28,12 @@ import static org.testng.Assert.fail;
 import org.testng.annotations.Test;
 
 import com.yahoo.sketches.SketchesArgumentException;
+
 /**
  * @author Lee Rhodes
  *
  */
+@SuppressWarnings("javadoc")
 public class TablesTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hll/ToFromByteArrayTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/ToFromByteArrayTest.java
@@ -31,8 +31,8 @@ import com.yahoo.memory.WritableMemory;
 
 /**
  * @author Lee Rhodes
- *
  */
+@SuppressWarnings("javadoc")
 public class ToFromByteArrayTest {
 
   static final int[] nArr = new int[] {1, 3, 10, 30, 100, 300, 1000, 3000, 10000, 30000};

--- a/src/test/java/com/yahoo/sketches/hll/UnionCaseTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/UnionCaseTest.java
@@ -33,8 +33,8 @@ import org.testng.annotations.Test;
 
 /**
  * @author Lee Rhodes
- *
  */
+@SuppressWarnings("javadoc")
 public class UnionCaseTest {
   long v = 0;
 

--- a/src/test/java/com/yahoo/sketches/hll/UnionTest.java
+++ b/src/test/java/com/yahoo/sketches/hll/UnionTest.java
@@ -36,6 +36,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class UnionTest {
   static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/com/yahoo/sketches/hllmap/CouponHashMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hllmap/CouponHashMapTest.java
@@ -25,9 +25,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.yahoo.sketches.SketchesArgumentException;
-import com.yahoo.sketches.hllmap.CouponHashMap;
-import com.yahoo.sketches.hllmap.Map;
 
+@SuppressWarnings("javadoc")
 public class CouponHashMapTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hllmap/CouponTraverseMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hllmap/CouponTraverseMapTest.java
@@ -24,8 +24,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.yahoo.sketches.hllmap.CouponTraverseMap;
-
+@SuppressWarnings("javadoc")
 public class CouponTraverseMapTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hllmap/HllMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hllmap/HllMapTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.sketches.Util;
 
+@SuppressWarnings("javadoc")
 public class HllMapTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hllmap/SingleCouponMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hllmap/SingleCouponMapTest.java
@@ -24,9 +24,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.yahoo.sketches.hllmap.Map;
-import com.yahoo.sketches.hllmap.SingleCouponMap;
-
+@SuppressWarnings("javadoc")
 public class SingleCouponMapTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/hllmap/UniqueCountMapTest.java
+++ b/src/test/java/com/yahoo/sketches/hllmap/UniqueCountMapTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.Util;
 
+@SuppressWarnings("javadoc")
 public class UniqueCountMapTest {
   private final static int INIT_ENTRIES = 211;
   @Test

--- a/src/test/java/com/yahoo/sketches/kll/DeprecatedAndMiscTest.java
+++ b/src/test/java/com/yahoo/sketches/kll/DeprecatedAndMiscTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DeprecatedAndMiscTest {
 
   @SuppressWarnings("deprecation")

--- a/src/test/java/com/yahoo/sketches/kll/KllFloatsSketchIteratorTest.java
+++ b/src/test/java/com/yahoo/sketches/kll/KllFloatsSketchIteratorTest.java
@@ -22,6 +22,7 @@ package com.yahoo.sketches.kll;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class KllFloatsSketchIteratorTest {
 
   @Test
@@ -46,7 +47,7 @@ public class KllFloatsSketchIteratorTest {
   public void bigSketches() {
     for (int n = 1000; n < 100000; n += 2000) {
       KllFloatsSketch sketch = new KllFloatsSketch();
-      for (int i = 0; i < n; i++) { 
+      for (int i = 0; i < n; i++) {
         sketch.update(i);
       }
       KllFloatsSketchIterator it = sketch.iterator();

--- a/src/test/java/com/yahoo/sketches/kll/KllFloatsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/kll/KllFloatsSketchTest.java
@@ -31,6 +31,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.tuple.TestUtil;
 
+@SuppressWarnings("javadoc")
 public class KllFloatsSketchTest {
 
   private static final double PMF_EPS_FOR_K_8 = 0.35; // PMF rank error (epsilon) for k=8
@@ -417,7 +418,7 @@ public class KllFloatsSketchTest {
     sketch.update(1);
     sketch.update(2);
     sketch.update(3);
-    final float[] quantiles1 = sketch.getQuantiles(new double[] {0, 0.5, 1}); 
+    final float[] quantiles1 = sketch.getQuantiles(new double[] {0, 0.5, 1});
     final float[] quantiles2 = sketch.getQuantiles(3);
     assertEquals(quantiles1, quantiles2);
     assertEquals(quantiles1[0], 1f);

--- a/src/test/java/com/yahoo/sketches/kll/KllValidationTest.java
+++ b/src/test/java/com/yahoo/sketches/kll/KllValidationTest.java
@@ -34,6 +34,7 @@ import org.testng.Assert;
 // These results are for the version that delays the rollup until the next value comes in.
 // The @Test annotations have to be enabled to use this class and a section in KllHelper also
 // needs to be enabled.
+@SuppressWarnings("javadoc")
 public class KllValidationTest {
 
   private static final long[] correctResultsWithReset = {

--- a/src/test/java/com/yahoo/sketches/quantiles/AccuracyTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/AccuracyTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class AccuracyTest {
   static Random rand = new Random();
 

--- a/src/test/java/com/yahoo/sketches/quantiles/DebugUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DebugUnionTest.java
@@ -33,6 +33,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DebugUnionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/DeprecatedAndMiscTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DeprecatedAndMiscTest.java
@@ -31,6 +31,7 @@ import com.yahoo.memory.WritableMemory;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DeprecatedAndMiscTest {
 
   @SuppressWarnings({ "deprecation", "unused" })

--- a/src/test/java/com/yahoo/sketches/quantiles/DirectCompactDoublesSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DirectCompactDoublesSketchTest.java
@@ -36,7 +36,9 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class DirectCompactDoublesSketchTest {
+
   @BeforeMethod
   public void setUp() {
     DoublesSketch.rand.setSeed(32749); // make sketches deterministic for testing

--- a/src/test/java/com/yahoo/sketches/quantiles/DirectQuantilesMemoryRequestTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DirectQuantilesMemoryRequestTest.java
@@ -35,6 +35,7 @@ import com.yahoo.memory.WritableMemory;
  * implementation that <i>owns</i> the native memory allocations, thus is responsible for
  * allocating larger Memory when requested and the actual freeing of the old memory allocations.
  */
+@SuppressWarnings("javadoc")
 public class DirectQuantilesMemoryRequestTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/DirectUpdateDoublesSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DirectUpdateDoublesSketchTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class DirectUpdateDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/com/yahoo/sketches/quantiles/DoublesSketchBuilderTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DoublesSketchBuilderTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class DoublesSketchBuilderTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/DoublesSketchIteratorTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DoublesSketchIteratorTest.java
@@ -22,6 +22,7 @@ package com.yahoo.sketches.quantiles;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class DoublesSketchIteratorTest {
 
   @Test
@@ -46,7 +47,7 @@ public class DoublesSketchIteratorTest {
   public void bigSketches() {
     for (int n = 1000; n < 100000; n += 2000) {
       UpdateDoublesSketch sketch = DoublesSketch.builder().build();
-      for (int i = 0; i < n; i++) { 
+      for (int i = 0; i < n; i++) {
         sketch.update(i);
       }
       DoublesSketchIterator it = sketch.iterator();

--- a/src/test/java/com/yahoo/sketches/quantiles/DoublesSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DoublesSketchTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.WritableDirectHandle;
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class DoublesSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/DoublesUnionBuilderTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DoublesUnionBuilderTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class DoublesUnionBuilderTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/DoublesUnionImplTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DoublesUnionImplTest.java
@@ -34,6 +34,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class DoublesUnionImplTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/DoublesUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/DoublesUtilTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class DoublesUtilTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/ForwardCompatibilityTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/ForwardCompatibilityTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.memory.Memory;
 
+@SuppressWarnings("javadoc")
 public class ForwardCompatibilityTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/HeapCompactDoublesSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/HeapCompactDoublesSketchTest.java
@@ -32,6 +32,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class HeapCompactDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/com/yahoo/sketches/quantiles/HeapUpdateDoublesSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/HeapUpdateDoublesSketchTest.java
@@ -44,6 +44,7 @@ import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.QuantilesHelper;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class HeapUpdateDoublesSketchTest {
 
   @BeforeMethod

--- a/src/test/java/com/yahoo/sketches/quantiles/ItemsSketchIteratorTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/ItemsSketchIteratorTest.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class ItemsSketchIteratorTest {
 
   @Test
@@ -48,7 +49,7 @@ public class ItemsSketchIteratorTest {
   public void bigSketches() {
     for (int n = 1000; n < 100000; n += 2000) {
       ItemsSketch<Integer> sketch = ItemsSketch.getInstance(128, Comparator.naturalOrder());
-      for (int i = 0; i < n; i++) { 
+      for (int i = 0; i < n; i++) {
         sketch.update(i);
       }
       ItemsSketchIterator<Integer> it = sketch.iterator();

--- a/src/test/java/com/yahoo/sketches/quantiles/ItemsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/ItemsSketchTest.java
@@ -37,6 +37,7 @@ import com.yahoo.sketches.ArrayOfLongsSerDe;
 import com.yahoo.sketches.ArrayOfStringsSerDe;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ItemsSketchTest {
 
   @BeforeMethod

--- a/src/test/java/com/yahoo/sketches/quantiles/ItemsUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/ItemsUnionTest.java
@@ -31,6 +31,7 @@ import com.yahoo.sketches.ArrayOfItemsSerDe;
 import com.yahoo.sketches.ArrayOfLongsSerDe;
 import com.yahoo.sketches.ArrayOfStringsSerDe;
 
+@SuppressWarnings("javadoc")
 public class ItemsUnionTest {
 
   @Test
@@ -348,20 +349,20 @@ public class ItemsUnionTest {
     skValid2 = buildIS(32, n, n);
     ItemsMergeImpl.mergeInto(skValid1, skValid2);
     Assert.assertEquals(skValid2.getMinValue(), 0.0, 0.0);
-    Assert.assertEquals(skValid2.getMaxValue(), 2 * n - 1.0, 0.0);
+    Assert.assertEquals(skValid2.getMaxValue(), (2 * n) - 1.0, 0.0);
 
     n = 512;
     skValid1 = buildIS(32, n, 0);
     skValid2 = buildIS(32, n, n);
     ItemsMergeImpl.mergeInto(skValid1, skValid2);
     Assert.assertEquals(skValid2.getMinValue(), 0.0, 0.0);
-    Assert.assertEquals(skValid2.getMaxValue(), 2 * n - 1.0, 0.0);
+    Assert.assertEquals(skValid2.getMaxValue(), (2 * n) - 1.0, 0.0);
 
     skValid1 = buildIS(32, n, 0);
     skValid2 = buildIS(32, n, n);
     ItemsMergeImpl.mergeInto(skValid2, skValid1);
     Assert.assertEquals(skValid1.getMinValue(), 0.0, 0.0);
-    Assert.assertEquals(skValid1.getMaxValue(), 2 * n - 1.0, 0.0);
+    Assert.assertEquals(skValid1.getMaxValue(), (2 * n) - 1.0, 0.0);
   }
 
   @Test
@@ -386,7 +387,7 @@ public class ItemsUnionTest {
     Assert.assertEquals(bytesOut.length, 8);
     Assert.assertTrue(union.isEmpty());
 
-    final byte[] byteArr = buildIS(k, 2 * k + 5).toByteArray(serDe);
+    final byte[] byteArr = buildIS(k, (2 * k) + 5).toByteArray(serDe);
     final Memory mem = Memory.wrap(byteArr);
     union = ItemsUnion.getInstance(mem, Comparator.naturalOrder(), serDe);
     bytesOut = union.toByteArray(serDe);

--- a/src/test/java/com/yahoo/sketches/quantiles/PreambleUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/PreambleUtilTest.java
@@ -43,6 +43,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableDirectHandle;
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/ReadOnlyMemoryTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/ReadOnlyMemoryTest.java
@@ -28,6 +28,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.SketchesReadOnlyException;
 
+@SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/quantiles/SerDeCompatibilityTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/SerDeCompatibilityTest.java
@@ -28,6 +28,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.sketches.ArrayOfDoublesSerDe;
 import com.yahoo.sketches.ArrayOfItemsSerDe;
 
+@SuppressWarnings("javadoc")
 public class SerDeCompatibilityTest {
 
   private static final ArrayOfItemsSerDe<Double> serDe = new ArrayOfDoublesSerDe();
@@ -59,7 +60,7 @@ public class SerDeCompatibilityTest {
     DoublesSketchTest.testSketchEquality(sketch1, cs);
     //final byte[] bytes = sketch1.compact().toByteArray(); // must be compact
     final byte[] bytes = cs.toByteArray(); // must be compact
-    
+
     //reconstruct with ItemsSketch
     final ItemsSketch<Double> sketch2 = ItemsSketch.getInstance(Memory.wrap(bytes),
         Comparator.naturalOrder(), serDe);
@@ -72,5 +73,5 @@ public class SerDeCompatibilityTest {
     // based on ~1.7% normalized rank error for this particular case
     Assert.assertEquals(sketch2.getQuantile(0.5), 500.0, 17);
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/quantiles/UtilTest.java
+++ b/src/test/java/com/yahoo/sketches/quantiles/UtilTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class UtilTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/sampling/ReservoirItemsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/ReservoirItemsSketchTest.java
@@ -46,6 +46,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.SketchesException;
 import com.yahoo.sketches.SketchesStateException;
 
+@SuppressWarnings("javadoc")
 public class ReservoirItemsSketchTest {
   private static final double EPS = 1e-8;
 

--- a/src/test/java/com/yahoo/sketches/sampling/ReservoirItemsUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/ReservoirItemsUnionTest.java
@@ -44,6 +44,7 @@ import com.yahoo.sketches.Family;
 import com.yahoo.sketches.SketchesArgumentException;
 
 // Tests mostly focus on Long since other types are already tested in ReservoirItemsSketchTest.
+@SuppressWarnings("javadoc")
 public class ReservoirItemsUnionTest {
   @Test
   public void checkEmptyUnion() {
@@ -321,7 +322,7 @@ public class ReservoirItemsUnionTest {
     assertEquals(riu.getResult().getK(), k); // power of 2, so exact
 
     data = new ArrayList<>(2 * k);
-    for (int i = 0; i < 2 * k; ++i) {
+    for (int i = 0; i < (2 * k); ++i) {
       data.add(i);
     }
     riu.update(10 * n, 2 * k, data);

--- a/src/test/java/com/yahoo/sketches/sampling/ReservoirLongsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/ReservoirLongsSketchTest.java
@@ -39,6 +39,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.SketchesException;
 import com.yahoo.sketches.SketchesStateException;
 
+@SuppressWarnings("javadoc")
 public class ReservoirLongsSketchTest {
   private static final double EPS = 1e-8;
 

--- a/src/test/java/com/yahoo/sketches/sampling/ReservoirLongsUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/ReservoirLongsUnionTest.java
@@ -37,6 +37,7 @@ import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.Family;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ReservoirLongsUnionTest {
   @Test
   public void checkEmptyUnion() {

--- a/src/test/java/com/yahoo/sketches/sampling/ReservoirSizeTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/ReservoirSizeTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ReservoirSizeTest {
   @Test
   public void checkComputeSize() {

--- a/src/test/java/com/yahoo/sketches/sampling/VarOptItemsSamplesTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/VarOptItemsSamplesTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.Test;
 /**
  * @author Jon Malkin
  */
+@SuppressWarnings("javadoc")
 public class VarOptItemsSamplesTest {
   @Test
   public void compareIteratorToArrays() {

--- a/src/test/java/com/yahoo/sketches/sampling/VarOptItemsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/VarOptItemsSketchTest.java
@@ -39,6 +39,7 @@ import com.yahoo.sketches.ResizeFactor;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.SketchesStateException;
 
+@SuppressWarnings("javadoc")
 public class VarOptItemsSketchTest {
   static final double EPS = 1e-10;
 

--- a/src/test/java/com/yahoo/sketches/sampling/VarOptItemsUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/sampling/VarOptItemsUnionTest.java
@@ -36,10 +36,10 @@ import com.yahoo.sketches.ArrayOfStringsSerDe;
 import com.yahoo.sketches.Family;
 import com.yahoo.sketches.SketchesArgumentException;
 
-
 /**
  * @author Jon Malkin
  */
+@SuppressWarnings("javadoc")
 public class VarOptItemsUnionTest {
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkBadSerVer() {
@@ -166,8 +166,8 @@ public class VarOptItemsUnionTest {
     sketch = getUnweightedLongsVIS(k, k + 1); // tau = (k + 1) / k
     union.update(sketch);
     result = union.getResult();
-    expectedWeight = 2.0 * n + k + 1;
-    assertEquals(result.getN(), 2 * n + k + 1);
+    expectedWeight = (2.0 * n) + k + 1;
+    assertEquals(result.getN(), (2 * n) + k + 1);
     assertEquals(result.getTotalWtR(), expectedWeight, EPS);
 
     union.reset();
@@ -237,7 +237,7 @@ public class VarOptItemsUnionTest {
 
     compareUnionsExact(union1, union2); // union2 should be unchanged
 
-    for (long i = 1; i < k - 1; ++i) {
+    for (long i = 1; i < (k - 1); ++i) {
       ris.update(i);
       vis.update(i, 1.0);
     }
@@ -312,7 +312,7 @@ public class VarOptItemsUnionTest {
     // reservoir tau will be greater than gadget's tau
     VarOptItemsSketch<Long> vis = VarOptItemsSketch.newInstance(k);
     ReservoirItemsSketch<Long> ris = ReservoirItemsSketch.newInstance(k);
-    for (long i = 1; i < 2 * n; ++i) {
+    for (long i = 1; i < (2 * n); ++i) {
       ris.update(i);
       vis.update(i, 1.0);
     }
@@ -324,7 +324,7 @@ public class VarOptItemsUnionTest {
     // reservoir tau will be smaller than gadget's tau
     vis = VarOptItemsSketch.newInstance(k);
     ris = ReservoirItemsSketch.newInstance(k);
-    for (long i = 1; i <= k + 1; ++i) {
+    for (long i = 1; i <= (k + 1); ++i) {
       ris.update(i);
       vis.update(i, 1.0);
     }

--- a/src/test/java/com/yahoo/sketches/theta/CompactSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/CompactSketchTest.java
@@ -36,6 +36,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class CompactSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/ConcurrentDirectQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/ConcurrentDirectQuickSelectSketchTest.java
@@ -39,6 +39,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author eshcar
  */
+@SuppressWarnings("javadoc")
 public class ConcurrentDirectQuickSelectSketchTest {
 
   private int lgK;

--- a/src/test/java/com/yahoo/sketches/theta/ConcurrentHeapQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/ConcurrentHeapQuickSelectSketchTest.java
@@ -42,6 +42,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author eshcar
  */
+@SuppressWarnings("javadoc")
 public class ConcurrentHeapQuickSelectSketchTest {
   private int lgK;
   private long seed = DEFAULT_UPDATE_SEED;

--- a/src/test/java/com/yahoo/sketches/theta/DirectIntersectionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/DirectIntersectionTest.java
@@ -41,6 +41,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectIntersectionTest {
   private static final int PREBYTES = CONST_PREAMBLE_LONGS << 3; //24
 

--- a/src/test/java/com/yahoo/sketches/theta/DirectQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/DirectQuickSelectSketchTest.java
@@ -55,6 +55,7 @@ import com.yahoo.sketches.SketchesReadOnlyException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectQuickSelectSketchTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/com/yahoo/sketches/theta/DirectUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/DirectUnionTest.java
@@ -42,6 +42,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class DirectUnionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/EmptyTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/EmptyTest.java
@@ -37,6 +37,7 @@ import com.yahoo.memory.WritableMemory;
  *
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class EmptyTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/ExamplesTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/ExamplesTest.java
@@ -21,25 +21,26 @@ package com.yahoo.sketches.theta;
 
 import org.testng.annotations.Test;
 
-/** 
+/**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class ExamplesTest {
-  
+
   @Test
   public void simpleCountingSketch() {
     int k = 4096;
     int u = 1000000;
-    
+
     UpdateSketch sketch = UpdateSketch.builder().setNominalEntries(k).build();
     for (int i = 0; i < u; i++) {
       sketch.update(i);
     }
-    
+
     println(sketch.toString());
   }
   /*
-### HeapQuickSelectSketch SUMMARY: 
+### HeapQuickSelectSketch SUMMARY:
    Nominal Entries (k)     : 4096
    Estimate                : 1002714.745231455
    Upper Bound, 95% conf   : 1027777.3354974985
@@ -57,17 +58,17 @@ public class ExamplesTest {
    Seed Hash               : ffff93cc
 ### END SKETCH SUMMARY
   */
-  
+
   @Test
   public void printlnTest() {
     println("PRINTING: "+this.getClass().getName());
   }
-  
+
   /**
-   * @param s value to print 
+   * @param s value to print
    */
   static void println(String s) {
     //System.out.println(s); //enable/disable here
   }
-  
+
 }

--- a/src/test/java/com/yahoo/sketches/theta/ForwardCompatibilityTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/ForwardCompatibilityTest.java
@@ -34,6 +34,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class ForwardCompatibilityTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/HeapAlphaSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAlphaSketchTest.java
@@ -50,6 +50,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class HeapAlphaSketchTest {
   private Family fam_ = ALPHA;
 

--- a/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapAnotBTest.java
@@ -34,6 +34,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class HeapAnotBTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/HeapIntersectionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapIntersectionTest.java
@@ -38,6 +38,7 @@ import com.yahoo.sketches.SketchesStateException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class HeapIntersectionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/HeapQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapQuickSelectSketchTest.java
@@ -51,6 +51,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class HeapQuickSelectSketchTest {
   private Family fam_ = QUICKSELECT;
 

--- a/src/test/java/com/yahoo/sketches/theta/HeapUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/HeapUnionTest.java
@@ -39,6 +39,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class HeapUnionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/IteratorTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/IteratorTest.java
@@ -29,6 +29,7 @@ import com.yahoo.sketches.Family;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class IteratorTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/JaccardSimilarityTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/JaccardSimilarityTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class JaccardSimilarityTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/PairwiseCornerCasesTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/PairwiseCornerCasesTest.java
@@ -34,6 +34,7 @@ import org.testng.annotations.Test;
 
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class PairwiseCornerCasesTest {
 
   Random rand = new Random(9001); //deterministic

--- a/src/test/java/com/yahoo/sketches/theta/PairwiseSetOperationsTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/PairwiseSetOperationsTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings("javadoc")
 public class PairwiseSetOperationsTest {
 
   // Intersection

--- a/src/test/java/com/yahoo/sketches/theta/PreambleUtilTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/PreambleUtilTest.java
@@ -66,6 +66,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class PreambleUtilTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/ReadOnlyMemoryTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/ReadOnlyMemoryTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.Memory;
 import com.yahoo.sketches.SketchesReadOnlyException;
 
+@SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/SetOperationTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SetOperationTest.java
@@ -46,6 +46,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class SetOperationTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/SingleItemSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SingleItemSketchTest.java
@@ -39,6 +39,7 @@ import com.yahoo.sketches.SketchesArgumentException;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class SingleItemSketchTest {
   final static short DEFAULT_SEED_HASH = (short) (computeSeedHash(DEFAULT_UPDATE_SEED) & 0XFFFFL);
 

--- a/src/test/java/com/yahoo/sketches/theta/SketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchTest.java
@@ -51,6 +51,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class SketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/SketchesTest.java
@@ -45,6 +45,7 @@ import com.yahoo.sketches.Util;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class SketchesTest {
 
   private static Memory getCompactSketchMemory(int k, int from, int to) {

--- a/src/test/java/com/yahoo/sketches/theta/UnionImplTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/UnionImplTest.java
@@ -34,6 +34,7 @@ import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.Util;
 
+@SuppressWarnings("javadoc")
 public class UnionImplTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/theta/UpdateSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/theta/UpdateSketchTest.java
@@ -35,9 +35,11 @@ import com.yahoo.sketches.Family;
 import com.yahoo.sketches.ResizeFactor;
 import com.yahoo.sketches.SketchesArgumentException;
 import com.yahoo.sketches.Util;
+
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class UpdateSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesAnotBTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesAnotBTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ArrayOfDoublesAnotBTest {
 
   @Test
@@ -219,11 +220,15 @@ public class ArrayOfDoublesAnotBTest {
   public void estimationMode() {
     int key = 0;
     ArrayOfDoublesUpdatableSketch sketchA = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 8192; i++) sketchA.update(key++, new double[] {1});
+    for (int i = 0; i < 8192; i++) {
+      sketchA.update(key++, new double[] {1});
+    }
 
     key -= 4096; // overlap half of the entries
     ArrayOfDoublesUpdatableSketch sketchB = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 8192; i++) sketchB.update(key++, new double[] {1});
+    for (int i = 0; i < 8192; i++) {
+      sketchB.update(key++, new double[] {1});
+    }
 
     ArrayOfDoublesAnotB aNotB = new ArrayOfDoublesSetOperationBuilder().buildAnotB();
     aNotB.update(sketchA, sketchB);
@@ -254,11 +259,15 @@ public class ArrayOfDoublesAnotBTest {
   public void estimationModeLargeB() {
     int key = 0;
     ArrayOfDoublesUpdatableSketch sketchA = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 10000; i++) sketchA.update(key++, new double[] {1});
+    for (int i = 0; i < 10000; i++) {
+      sketchA.update(key++, new double[] {1});
+    }
 
     key -= 2000; // overlap
     ArrayOfDoublesUpdatableSketch sketchB = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 100000; i++) sketchB.update(key++, new double[] {1});
+    for (int i = 0; i < 100000; i++) {
+      sketchB.update(key++, new double[] {1});
+    }
 
     final int expected = 10000 - 2000;
     ArrayOfDoublesAnotB aNotB = new ArrayOfDoublesSetOperationBuilder().buildAnotB();

--- a/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesCompactSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesCompactSketchTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 
+@SuppressWarnings("javadoc")
 public class ArrayOfDoublesCompactSketchTest {
   @Test
   public void heapToDirectExactTwoDoubles() {

--- a/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesIntersectionTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesIntersectionTest.java
@@ -25,11 +25,14 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ArrayOfDoublesIntersectionTest {
   private static ArrayOfDoublesCombiner combiner = new ArrayOfDoublesCombiner() {
     @Override
     public double[] combine(double[] a, double[] b) {
-      for (int i = 0; i < a.length; i++) a[i] += b[i];
+      for (int i = 0; i < a.length; i++) {
+        a[i] += b[i];
+      }
       return a;
     }
   };
@@ -143,7 +146,9 @@ public class ArrayOfDoublesIntersectionTest {
     Assert.assertEquals(result.getLowerBound(1), 1.0);
     Assert.assertEquals(result.getUpperBound(1), 1.0);
     double[][] values = result.getValues();
-    for (int i = 0; i < values.length; i++) Assert.assertEquals(values[i][0], 4.0);
+    for (int i = 0; i < values.length; i++) {
+      Assert.assertEquals(values[i][0], 4.0);
+    }
 
     intersection.reset();
     intersection.update(null, null);
@@ -159,10 +164,14 @@ public class ArrayOfDoublesIntersectionTest {
   public void heapDisjointEstimationMode() {
     int key = 0;
     ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 8192; i++) sketch1.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch1.update(key++, new double[] {1.0});
+    }
 
     ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 8192; i++) sketch2.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch2.update(key++, new double[] {1.0});
+    }
 
     ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
     intersection.update(sketch1, combiner);
@@ -181,11 +190,15 @@ public class ArrayOfDoublesIntersectionTest {
     int key = 0;
     ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().
         build(WritableMemory.wrap(new byte[1000000]));
-    for (int i = 0; i < 8192; i++) sketch1.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch1.update(key++, new double[] {1.0});
+    }
 
     ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().
         build(WritableMemory.wrap(new byte[1000000]));
-    for (int i = 0; i < 8192; i++) sketch2.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch2.update(key++, new double[] {1.0});
+    }
 
     ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().
         buildIntersection(WritableMemory.wrap(new byte[1000000]));
@@ -204,11 +217,15 @@ public class ArrayOfDoublesIntersectionTest {
   public void heapEstimationMode() {
     int key = 0;
     ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 8192; i++) sketch1.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch1.update(key++, new double[] {1.0});
+    }
 
     key -= 4096; // overlap half of the entries
     ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build();
-    for (int i = 0; i < 8192; i++) sketch2.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch2.update(key++, new double[] {1.0});
+    }
 
     ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection();
     intersection.update(sketch1, combiner);
@@ -219,18 +236,24 @@ public class ArrayOfDoublesIntersectionTest {
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
     double[][] values = result.getValues();
-    for (int i = 0; i < values.length; i++) Assert.assertEquals(values[i][0], 2.0);
+    for (int i = 0; i < values.length; i++) {
+      Assert.assertEquals(values[i][0], 2.0);
+    }
   }
 
   @Test
   public void directEstimationMode() {
     int key = 0;
     ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
-    for (int i = 0; i < 8192; i++) sketch1.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch1.update(key++, new double[] {1.0});
+    }
 
     key -= 4096; // overlap half of the entries
     ArrayOfDoublesUpdatableSketch sketch2 = new ArrayOfDoublesUpdatableSketchBuilder().build(WritableMemory.wrap(new byte[1000000]));
-    for (int i = 0; i < 8192; i++) sketch2.update(key++, new double[] {1.0});
+    for (int i = 0; i < 8192; i++) {
+      sketch2.update(key++, new double[] {1.0});
+    }
 
     ArrayOfDoublesIntersection intersection = new ArrayOfDoublesSetOperationBuilder().buildIntersection(WritableMemory.wrap(new byte[1000000]));
     intersection.update(sketch1, combiner);
@@ -241,7 +264,9 @@ public class ArrayOfDoublesIntersectionTest {
     Assert.assertTrue(result.getLowerBound(1) <= result.getEstimate());
     Assert.assertTrue(result.getUpperBound(1) > result.getEstimate());
     double[][] values = result.getValues();
-    for (int i = 0; i < values.length; i++) Assert.assertEquals(values[i][0], 2.0);
+    for (int i = 0; i < values.length; i++) {
+      Assert.assertEquals(values[i][0], 2.0);
+    }
   }
 
   @Test
@@ -270,7 +295,9 @@ public class ArrayOfDoublesIntersectionTest {
     Assert.assertEquals(result.getLowerBound(1), 1.0);
     Assert.assertEquals(result.getUpperBound(1), 1.0);
     double[][] values = result.getValues();
-    for (int i = 0; i < values.length; i++) Assert.assertEquals(values[i][0], 4.0);
+    for (int i = 0; i < values.length; i++) {
+      Assert.assertEquals(values[i][0], 4.0);
+    }
   }
 
   @Test(expectedExceptions = SketchesArgumentException.class)

--- a/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesQuickSelectSketchTest.java
@@ -26,6 +26,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ArrayOfDoublesQuickSelectSketchTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)
@@ -36,7 +37,7 @@ public class ArrayOfDoublesQuickSelectSketchTest {
   @Test
   public void heapToDirectExactTwoDoubles() {
     double[] valuesArr = {1.0, 2.0};
-    ArrayOfDoublesUpdatableSketch sketch1 = 
+    ArrayOfDoublesUpdatableSketch sketch1 =
         new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
     sketch1.update("a", valuesArr);
     sketch1.update("b", valuesArr);
@@ -69,7 +70,7 @@ public class ArrayOfDoublesQuickSelectSketchTest {
     long seed = 1;
     double[] values = {1.0};
 
-    ArrayOfDoublesUpdatableSketch sketch1 = 
+    ArrayOfDoublesUpdatableSketch sketch1 =
         new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build();
     sketch1.update("a", values);
     sketch1.update("b", values);
@@ -85,15 +86,15 @@ public class ArrayOfDoublesQuickSelectSketchTest {
 
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void checkInsertExceptions() {
-    ArrayOfDoublesUpdatableSketch sketch1 = 
+    ArrayOfDoublesUpdatableSketch sketch1 =
         new ArrayOfDoublesUpdatableSketchBuilder().setNumberOfValues(2).build();
     sketch1.update("a", new double[] {1.0});
   }
-  
+
   @Test
   public void directToHeapExactTwoDoubles() {
     double[] valuesArr = {1.0, 2.0};
-    ArrayOfDoublesUpdatableSketch sketch1 = 
+    ArrayOfDoublesUpdatableSketch sketch1 =
         new ArrayOfDoublesUpdatableSketchBuilder().
         setNumberOfValues(2).build(WritableMemory.wrap(new byte[1000000]));
     sketch1.update("a", valuesArr);
@@ -121,13 +122,13 @@ public class ArrayOfDoublesQuickSelectSketchTest {
       Assert.assertEquals(array[1], 4.0);
     }
   }
-  
+
   @Test
   public void directToHeapWithSeed() {
     long seed = 1;
     double[] values = {1.0};
 
-    ArrayOfDoublesUpdatableSketch sketch1 = 
+    ArrayOfDoublesUpdatableSketch sketch1 =
         new ArrayOfDoublesUpdatableSketchBuilder().setSeed(seed).build(
             WritableMemory.wrap(new byte[1000000]));
     sketch1.update("a", values);

--- a/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesUnionTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/ArrayOfDoublesUnionTest.java
@@ -28,6 +28,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class ArrayOfDoublesUnionTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/tuple/CompactSketchWithDoubleSummaryTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/CompactSketchWithDoubleSummaryTest.java
@@ -28,10 +28,11 @@ import com.yahoo.sketches.tuple.adouble.DoubleSummary;
 import com.yahoo.sketches.tuple.adouble.DoubleSummaryDeserializer;
 import com.yahoo.sketches.tuple.adouble.DoubleSummaryFactory;
 
+@SuppressWarnings("javadoc")
 public class CompactSketchWithDoubleSummaryTest {
   @Test
   public void emptyFromNonPublicConstructorNullArray() {
-    CompactSketch<DoubleSummary> sketch = new CompactSketch<DoubleSummary>(null, null, Long.MAX_VALUE, true);
+    CompactSketch<DoubleSummary> sketch = new CompactSketch<>(null, null, Long.MAX_VALUE, true);
     Assert.assertTrue(sketch.isEmpty());
     Assert.assertFalse(sketch.isEstimationMode());
     Assert.assertEquals(sketch.getEstimate(), 0.0);
@@ -49,7 +50,7 @@ public class CompactSketchWithDoubleSummaryTest {
   public void emptyFromNonPublicConstructor() {
     long[] keys = new long[0];
     DoubleSummary[] summaries = (DoubleSummary[]) java.lang.reflect.Array.newInstance(DoubleSummary.class, 0);
-    CompactSketch<DoubleSummary> sketch = new CompactSketch<DoubleSummary>(keys, summaries, Long.MAX_VALUE, true);
+    CompactSketch<DoubleSummary> sketch = new CompactSketch<>(keys, summaries, Long.MAX_VALUE, true);
     Assert.assertTrue(sketch.isEmpty());
     Assert.assertFalse(sketch.isEstimationMode());
     Assert.assertEquals(sketch.getEstimate(), 0.0);
@@ -136,7 +137,9 @@ public class CompactSketchWithDoubleSummaryTest {
   @Test
   public void serializeDeserializeEstimation() throws Exception {
     UpdatableSketch<Double, DoubleSummary> us = new UpdatableSketchBuilder<>(new DoubleSummaryFactory()).build();
-    for (int i = 0; i < 8192; i++) us.update(i, 1.0);
+    for (int i = 0; i < 8192; i++) {
+      us.update(i, 1.0);
+    }
     us.trim();
     CompactSketch<DoubleSummary> sketch1 = us.compact();
     byte[] bytes = sketch1.toByteArray();
@@ -162,7 +165,9 @@ public class CompactSketchWithDoubleSummaryTest {
   @Test(expectedExceptions = SketchesArgumentException.class)
   public void deserializeWrongType() {
     UpdatableSketch<Double, DoubleSummary> us = new UpdatableSketchBuilder<>(new DoubleSummaryFactory()).build();
-    for (int i = 0; i < 8192; i++) us.update(i, 1.0);
+    for (int i = 0; i < 8192; i++) {
+      us.update(i, 1.0);
+    }
     CompactSketch<DoubleSummary> sketch1 = us.compact();
     Sketches.heapifyUpdatableSketch(Memory.wrap(sketch1.toByteArray()), new DoubleSummaryDeserializer(),
         new DoubleSummaryFactory());

--- a/src/test/java/com/yahoo/sketches/tuple/DirectArrayOfDoublesCompactSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/DirectArrayOfDoublesCompactSketchTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class DirectArrayOfDoublesCompactSketchTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/tuple/DirectArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/DirectArrayOfDoublesQuickSelectSketchTest.java
@@ -26,6 +26,7 @@ import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.ResizeFactor;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class DirectArrayOfDoublesQuickSelectSketchTest {
   @Test
   public void isEmpty() {

--- a/src/test/java/com/yahoo/sketches/tuple/FilterTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/FilterTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.Test;
 import com.yahoo.sketches.tuple.adouble.DoubleSummary;
 import com.yahoo.sketches.tuple.adouble.DoubleSummaryFactory;
 
+@SuppressWarnings("javadoc")
 public class FilterTest {
 
     private static final int numberOfElements = 100;

--- a/src/test/java/com/yahoo/sketches/tuple/HeapArrayOfDoublesCompactSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/HeapArrayOfDoublesCompactSketchTest.java
@@ -26,6 +26,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class HeapArrayOfDoublesCompactSketchTest {
   @Test
   public void emptyFromQuickSelectSketch() {

--- a/src/test/java/com/yahoo/sketches/tuple/HeapArrayOfDoublesQuickSelectSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/HeapArrayOfDoublesQuickSelectSketchTest.java
@@ -26,6 +26,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.memory.WritableMemory;
 import com.yahoo.sketches.ResizeFactor;
 
+@SuppressWarnings("javadoc")
 public class HeapArrayOfDoublesQuickSelectSketchTest {
   @Test
   public void isEmpty() {
@@ -76,7 +77,9 @@ public class HeapArrayOfDoublesQuickSelectSketchTest {
     ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().build();
     Assert.assertTrue(sketch.isEmpty());
     Assert.assertEquals(sketch.getEstimate(), 0.0);
-    for (int i = 1; i <= 4096; i++) sketch.update(i, new double[] {1.0});
+    for (int i = 1; i <= 4096; i++) {
+      sketch.update(i, new double[] {1.0});
+    }
     Assert.assertFalse(sketch.isEmpty());
     Assert.assertFalse(sketch.isEstimationMode());
     Assert.assertEquals(sketch.getEstimate(), 4096.0);
@@ -88,9 +91,15 @@ public class HeapArrayOfDoublesQuickSelectSketchTest {
     double[][] values = sketch.getValues();
     Assert.assertEquals(values.length, 4096);
     int count = 0;
-    for (int i = 0; i < values.length; i++) if (values[i] != null) count++;
+    for (int i = 0; i < values.length; i++) {
+      if (values[i] != null) {
+        count++;
+      }
+    }
     Assert.assertEquals(count, 4096);
-    for (int i = 0; i < 4096; i++) Assert.assertEquals(values[i][0], 1.0);
+    for (int i = 0; i < 4096; i++) {
+      Assert.assertEquals(values[i][0], 1.0);
+    }
 
     sketch.reset();
     Assert.assertTrue(sketch.isEmpty());
@@ -112,7 +121,9 @@ public class HeapArrayOfDoublesQuickSelectSketchTest {
   public void estimationMode() {
     ArrayOfDoublesUpdatableSketch sketch = new ArrayOfDoublesUpdatableSketchBuilder().build();
     Assert.assertEquals(sketch.getEstimate(), 0.0);
-    for (int i = 1; i <= 8192; i++) sketch.update(i, new double[] {1.0});
+    for (int i = 1; i <= 8192; i++) {
+      sketch.update(i, new double[] {1.0});
+    }
     Assert.assertTrue(sketch.isEstimationMode());
     Assert.assertEquals(sketch.getEstimate(), 8192, 8192 * 0.01);
     Assert.assertTrue(sketch.getEstimate() >= sketch.getLowerBound(1));
@@ -197,10 +208,12 @@ public class HeapArrayOfDoublesQuickSelectSketchTest {
     ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().
         setResizeFactor(ResizeFactor.X1).build();
     for (int j = 0; j < 10; j++) {
-      for (int i = 0; i < 8192; i++) sketch1.update(i, new double[] {1.0});
+      for (int i = 0; i < 8192; i++) {
+        sketch1.update(i, new double[] {1.0});
+      }
     }
     byte[] byteArray = sketch1.toByteArray();
-    
+
     //for visual testing
     //TestUtil.writeBytesToFile(byteArray, "ArrayOfDoublesQuickSelectSketch4K.data");
 
@@ -210,7 +223,9 @@ public class HeapArrayOfDoublesQuickSelectSketchTest {
     Assert.assertEquals(sketch1.getTheta(), sketch2.getTheta());
     double[][] values = sketch2.getValues();
     Assert.assertTrue(values.length >= 4096);
-    for (double[] array: values) Assert.assertEquals(array[0], 10.0);
+    for (double[] array: values) {
+      Assert.assertEquals(array[0], 10.0);
+    }
   }
 
   @Test
@@ -218,7 +233,9 @@ public class HeapArrayOfDoublesQuickSelectSketchTest {
     int sketchSize = 16384;
     int numberOfUniques = sketchSize;
     ArrayOfDoublesUpdatableSketch sketch1 = new ArrayOfDoublesUpdatableSketchBuilder().setNominalEntries(sketchSize).setSamplingProbability(0.5f).build();
-    for (int i = 0; i < numberOfUniques; i++) sketch1.update(i, new double[] {1.0});
+    for (int i = 0; i < numberOfUniques; i++) {
+      sketch1.update(i, new double[] {1.0});
+    }
     ArrayOfDoublesSketch sketch2 = ArrayOfDoublesSketch.heapify(Memory.wrap(sketch1.toByteArray()));
     Assert.assertTrue(sketch2.isEstimationMode());
     Assert.assertEquals(sketch2.getEstimate() / numberOfUniques, 1.0, 0.01);

--- a/src/test/java/com/yahoo/sketches/tuple/ReadOnlyMemoryTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/ReadOnlyMemoryTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 import com.yahoo.memory.Memory;
 import com.yahoo.sketches.SketchesReadOnlyException;
 
+@SuppressWarnings("javadoc")
 public class ReadOnlyMemoryTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/tuple/SerializerDeserializerTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/SerializerDeserializerTest.java
@@ -26,6 +26,7 @@ import com.yahoo.memory.Memory;
 import com.yahoo.sketches.Family;
 import com.yahoo.sketches.SketchesArgumentException;
 
+@SuppressWarnings("javadoc")
 public class SerializerDeserializerTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/tuple/TestUtil.java
+++ b/src/test/java/com/yahoo/sketches/tuple/TestUtil.java
@@ -27,22 +27,29 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@SuppressWarnings("javadoc")
 public class TestUtil {
   public static List<Double> asList(double[] array) {
-    List<Double> list = new ArrayList<Double>(array.length);
-    for (int i = 0; i < array.length; i++) list.add(array[i]);
+    List<Double> list = new ArrayList<>(array.length);
+    for (int i = 0; i < array.length; i++) {
+      list.add(array[i]);
+    }
     return list;
   }
 
   public static List<Float> asList(float[] array) {
-    List<Float> list = new ArrayList<Float>(array.length);
-    for (int i = 0; i < array.length; i++) list.add(array[i]);
+    List<Float> list = new ArrayList<>(array.length);
+    for (int i = 0; i < array.length; i++) {
+      list.add(array[i]);
+    }
     return list;
   }
 
   public static List<Long> asList(long[] array) {
-    List<Long> list = new ArrayList<Long>(array.length);
-    for (int i = 0; i < array.length; i++) list.add(array[i]);
+    List<Long> list = new ArrayList<>(array.length);
+    for (int i = 0; i < array.length; i++) {
+      list.add(array[i]);
+    }
     return list;
   }
 
@@ -51,7 +58,7 @@ public class TestUtil {
       out.write(bytes);
     }
   }
-  
+
   public static byte[] readBytesFromFile(String fileName) throws IOException {
     try (FileInputStream in = new FileInputStream(new File(fileName))) {
       ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/test/java/com/yahoo/sketches/tuple/adouble/UpdatableSketchWithDoubleSummaryTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/adouble/UpdatableSketchWithDoubleSummaryTest.java
@@ -36,6 +36,7 @@ import com.yahoo.sketches.tuple.UpdatableSketch;
 import com.yahoo.sketches.tuple.UpdatableSketchBuilder;
 import com.yahoo.sketches.tuple.adouble.DoubleSummary.Mode;
 
+@SuppressWarnings("javadoc")
 public class UpdatableSketchWithDoubleSummaryTest {
 
   @Test

--- a/src/test/java/com/yahoo/sketches/tuple/strings/ArrayOfStringsSketchTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/strings/ArrayOfStringsSketchTest.java
@@ -34,6 +34,7 @@ import com.yahoo.sketches.tuple.Union;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class ArrayOfStringsSketchTest {
   private static final String LS = System.getProperty("line.separator");
 

--- a/src/test/java/com/yahoo/sketches/tuple/strings/ArrayOfStringsSummaryTest.java
+++ b/src/test/java/com/yahoo/sketches/tuple/strings/ArrayOfStringsSummaryTest.java
@@ -32,6 +32,7 @@ import com.yahoo.sketches.tuple.DeserializeResult;
 /**
  * @author Lee Rhodes
  */
+@SuppressWarnings("javadoc")
 public class ArrayOfStringsSummaryTest {
 
   @Test


### PR DESCRIPTION
Unfortunately, every test file has to have a SuppressWarnings("javadoc")
at the top of the class. There is no way to have Eclipse just check the
main branch.