### PR TITLE
Provide a way to merge Kll sketches deterministically

### DIFF
--- a/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllItemsSketch.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.Random;
 
 import org.apache.datasketches.common.ArrayOfItemsSerDe;
 import org.apache.datasketches.common.SketchesArgumentException;
@@ -262,12 +263,12 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   }
 
   @Override
-  public final void merge(final KllSketch other) {
+  public final void merge(final KllSketch other, final Random random) {
     if (readOnly || (sketchStructure != UPDATABLE)) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
     if (this == other) { throw new SketchesArgumentException(SELF_MERGE_MSG); }
     final KllItemsSketch<T> othItmSk = (KllItemsSketch<T>)other;
     if (othItmSk.isEmpty()) { return; }
-    KllItemsHelper.mergeItemImpl(this, othItmSk, comparator);
+    KllItemsHelper.mergeItemImpl(this, othItmSk, comparator, random);
     itemsSV = null;
   }
 
@@ -309,7 +310,7 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
   public void update(final T item) {
     if (item == null) { return; } //ignore
     if (readOnly) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
-    KllItemsHelper.updateItem(this, item);
+    KllItemsHelper.updateItem(this, item, random);
     itemsSV = null;
   }
 
@@ -322,8 +323,8 @@ public abstract class KllItemsSketch<T> extends KllSketch implements QuantilesGe
     if (item == null) { return; } //ignore
     if (readOnly) { throw new SketchesArgumentException(TGT_IS_READ_ONLY_MSG); }
     if (weight < 1L) { throw new SketchesArgumentException("Weight is less than one."); }
-    if (weight == 1L) { KllItemsHelper.updateItem(this, item); }
-    else { KllItemsHelper.updateItem(this, item, weight); }
+    if (weight == 1L) { KllItemsHelper.updateItem(this, item, random); }
+    else { KllItemsHelper.updateItem(this, item, weight, random); }
     itemsSV = null;
   }
 

--- a/src/main/java/org/apache/datasketches/kll/KllSketch.java
+++ b/src/main/java/org/apache/datasketches/kll/KllSketch.java
@@ -267,7 +267,21 @@ public abstract class KllSketch implements QuantilesAPI, MemorySegmentStatus {
    * Attempting to merge a sketch of the wrong type will throw an exception.
    * @param other sketch to merge into this one
    */
-  public abstract void merge(KllSketch other);
+  public final void merge(KllSketch other) {
+    merge(other, random);
+  }
+
+  /**
+   * Merges another sketch into this one.
+   * Attempting to merge a sketch of the wrong type will throw an exception.
+   *
+   * <p><b>Warning:</b> providing a custom number generator might break the
+   * error bounds of the KllSketch.</p>
+   *
+   * @param other sketch to merge into this one
+   * @param random random number generator to be used
+   */
+  public abstract void merge(KllSketch other, Random random);
 
   @Override
   public final String toString() {


### PR DESCRIPTION
As explained in https://github.com/apache/datasketches-java/issues/693, it would be very helpful for certain downstream projects to be able to use the KLL sketches, while still getting a deterministic result.

This PR proposes to add a method `KllSketch#merge(KllSketch, Random)` as an alternative. Existing code will continue to run as before. New callers can consider to use the newly added method if they need deterministic results. A warning has been added to the javadoc of the new method, to make it clear that the error guarantees of the KLL sketch algorithm might no longer be valid.