### PR TITLE
Allow override surefire plugin group

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,20 @@ under the License.
   </dependencies>
 
   <build>
+      <pluginManagement>
+          <plugins>
+              <plugin>
+                  <!-- Apache Parent pom, pluginManagement-->
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <configuration>
+                      <!-- by default, exclude all snapshot targets -->
+                      <!-- this will be overridden on dedicated profile -->
+                      <excludedGroups>${testng.generate-java-files},${testng.check-cpp-files},${testng.check-go-files},${testng.check-cpp-historical-files}</excludedGroups>
+                  </configuration>
+              </plugin>
+          </plugins>
+      </pluginManagement>
       <plugins>
 
       <plugin>
@@ -143,7 +157,7 @@ under the License.
           <fork>true</fork>
           <release>${java.version}</release>
           <compilerArgs>
-            <arg>-J${jvm.options}</arg> <!-- comma separated or separate args --> 
+            <arg>-J${jvm.options}</arg> <!-- comma separated or separate args -->
           </compilerArgs>
         </configuration>
       </plugin>
@@ -224,7 +238,7 @@ under the License.
           <doclint>all,-missing</doclint>
           <release>${java.version}</release>
           <additionalJOptions> <!-- requires -J prefix -->
-            <additionalJoption>-J${jvm.options}</additionalJoption> 
+            <additionalJoption>-J${jvm.options}</additionalJoption>
         </additionalJOptions>
         </configuration>
         <executions>
@@ -274,8 +288,6 @@ under the License.
           <useManifestOnlyJar>false</useManifestOnlyJar>
           <redirectTestOutputToFile>true</redirectTestOutputToFile>
           <reportsDirectory>${project.build.directory}/test-output/${maven.build.timestamp}</reportsDirectory>
-          <excludedGroups>${testng.generate-java-files},${testng.check-cpp-files},${testng.check-go-files},
-${testng.check-cpp-historical-files}</excludedGroups> <!-- do not indent -->
         </configuration>
       </plugin>
 
@@ -581,7 +593,7 @@ ${testng.check-cpp-historical-files}</excludedGroups> <!-- do not indent -->
         </pluginManagement>
       </build>
     </profile>
-    
+
     <profile>
       <id>check-cpp-historical-files</id>
       <build>


### PR DESCRIPTION
Previously, the exclude all groups config is defined in `/plugins/plugin` and thus it overrides any other configs defined in the `/pluginManagement` section.