### PR TITLE
test: array of strings tuple sketch cross language

### DIFF
--- a/src/test/java/org/apache/datasketches/tuple/strings/AosSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/tuple/strings/AosSketchCrossLanguageTest.java
@@ -72,7 +72,7 @@ public class AosSketchCrossLanguageTest {
 
   @Test(groups = {GENERATE_JAVA_FILES})
   public void generateBinariesForCompatibilityTestingMultiKeyStrings() throws IOException {
-    int[] nArr = {0, 1, 10, 100, 1000, 10_000};
+    int[] nArr = {0, 1, 10, 100, 1000, 10_000, 100_000, 1_000_000};
     for (int n : nArr) {
       ArrayOfStringsTupleSketch sk = new ArrayOfStringsTupleSketch();
       for (int i = 0; i < n; i++) {


### PR DESCRIPTION
I'm working on AoS tuple sketch for C++ and go.

To verify compatibility, add cross language test cases. 

Same coverage AoD Tuple Sketch and special cases for AoS sketch. 
1. Key is array of strings 
2. following utf8 encoding. 
3. empty string case