### PR TITLE
BloomFilterBuilder.validateSizeInputs should not accept numBits=0

### DIFF
--- a/src/main/java/org/apache/datasketches/filters/bloomfilter/BloomFilterBuilder.java
+++ b/src/main/java/org/apache/datasketches/filters/bloomfilter/BloomFilterBuilder.java
@@ -235,7 +235,7 @@ public final class BloomFilterBuilder {
   }
 
   private static void validateSizeInputs(final long numBits, final int numHashes) {
-    if (numBits < 0) {
+    if (numBits <= 0) {
       throw new SketchesArgumentException("Size of BloomFilter must be strictly positive. "
               + "Requested: " + numBits);
     }


### PR DESCRIPTION
"Size of BloomFilter must be strictly positive."