### PR TITLE
fix: respect negative values on deserialization in REQ sketch

### DIFF
--- a/src/main/java/org/apache/datasketches/req/ReqSerDe.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSerDe.java
@@ -205,7 +205,7 @@ class ReqSerDe {
     final float[] arr = new float[count];
     posSeg.getFloatArray(arr, 0, count);
     float minItem = Float.MAX_VALUE;
-    float maxItem = Float.MIN_VALUE;
+    float maxItem = -Float.MAX_VALUE;
     for (int i = 0; i < count; i++) {
       minItem = min(minItem, arr[i]);
       maxItem = max(maxItem, arr[i]);

--- a/src/main/java/org/apache/datasketches/req/ReqSerDe.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSerDe.java
@@ -19,14 +19,16 @@
 
 package org.apache.datasketches.req;
 
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.round;
+
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.positional.PositionalSegment;
-
-import static java.lang.Math.*;
 
 /**
  * This class handles serialization and deserialization.
@@ -205,11 +207,6 @@ class ReqSerDe {
     float minItem = Float.POSITIVE_INFINITY;
     float maxItem = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < count; i++) {
-      final float item = arr[i];
-      if (Float.isNaN(item)) {
-        continue;
-      }
-
       minItem = min(minItem, arr[i]);
       maxItem = max(maxItem, arr[i]);
     }

--- a/src/main/java/org/apache/datasketches/req/ReqSerDe.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSerDe.java
@@ -20,7 +20,6 @@
 package org.apache.datasketches.req;
 
 import static java.lang.Math.max;
-import static java.lang.Math.min;
 import static java.lang.Math.round;
 
 import java.lang.foreign.MemorySegment;
@@ -204,11 +203,17 @@ class ReqSerDe {
     final int count = posSeg.getInt();
     final float[] arr = new float[count];
     posSeg.getFloatArray(arr, 0, count);
-    float minItem = Float.MAX_VALUE;
-    float maxItem = -Float.MAX_VALUE;
+    float minItem = Float.NaN;
+    float maxItem = Float.NaN;
     for (int i = 0; i < count; i++) {
-      minItem = min(minItem, arr[i]);
-      maxItem = max(maxItem, arr[i]);
+      final float item = arr[i];
+      if (Float.isNaN(minItem)) {
+        minItem = item;
+        maxItem = item;
+      } else {
+        if (item < minItem) { minItem = item; }
+        if (item > maxItem) { maxItem = item; }
+      }
     }
     final int delta = 2 * sectionSize * numSections;
     final int nomCap = 2 * delta;

--- a/src/main/java/org/apache/datasketches/req/ReqSerDe.java
+++ b/src/main/java/org/apache/datasketches/req/ReqSerDe.java
@@ -19,15 +19,14 @@
 
 package org.apache.datasketches.req;
 
-import static java.lang.Math.max;
-import static java.lang.Math.round;
-
 import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.datasketches.common.Family;
 import org.apache.datasketches.common.positional.PositionalSegment;
+
+import static java.lang.Math.*;
 
 /**
  * This class handles serialization and deserialization.
@@ -203,17 +202,16 @@ class ReqSerDe {
     final int count = posSeg.getInt();
     final float[] arr = new float[count];
     posSeg.getFloatArray(arr, 0, count);
-    float minItem = Float.NaN;
-    float maxItem = Float.NaN;
+    float minItem = Float.POSITIVE_INFINITY;
+    float maxItem = Float.NEGATIVE_INFINITY;
     for (int i = 0; i < count; i++) {
       final float item = arr[i];
-      if (Float.isNaN(minItem)) {
-        minItem = item;
-        maxItem = item;
-      } else {
-        if (item < minItem) { minItem = item; }
-        if (item > maxItem) { maxItem = item; }
+      if (Float.isNaN(item)) {
+        continue;
       }
+
+      minItem = min(minItem, arr[i]);
+      maxItem = max(maxItem, arr[i]);
     }
     final int delta = 2 * sectionSize * numSections;
     final int nomCap = 2 * delta;

--- a/src/test/java/org/apache/datasketches/req/ReqCompactorTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqCompactorTest.java
@@ -101,4 +101,47 @@ public class ReqCompactorTest {
     assertEquals(fbuf2.getDelta(), delta);
     assertTrue(fbuf.isEqualTo(fbuf2));
   }
+
+  @Test
+  public void checkSerDeWithNegativeValues() {
+    checkSerDeNegativeImpl(12, false);
+    checkSerDeNegativeImpl(12, true);
+  }
+
+  private static void checkSerDeNegativeImpl(final int k, final boolean hra) {
+    final ReqCompactor c1 = new ReqCompactor((byte)0, hra, k, null);
+    final int nomCap = 2 * 3 * k;
+    final FloatBuffer fbuf = c1.getBuffer();
+
+    for (int i = 1; i <= nomCap; i++) {
+      fbuf.append(-i); //all negative values
+    }
+    final byte[] c1ser = c1.toByteArray();
+    final PositionalSegment posSeg = PositionalSegment.wrap(MemorySegment.ofArray(c1ser));
+    final Compactor compactor = ReqSerDe.extractCompactor(posSeg, fbuf.isSorted(), hra);
+    assertEquals(compactor.minItem, -nomCap);
+    assertEquals(compactor.maxItem, -1f);
+  }
+
+  @Test
+  public void checkSerDeWithMixedValues() {
+    checkSerDeMixedImpl(12, false);
+    checkSerDeMixedImpl(12, true);
+  }
+
+  private static void checkSerDeMixedImpl(final int k, final boolean hra) {
+    final ReqCompactor c1 = new ReqCompactor((byte)0, hra, k, null);
+    final int nomCap = 2 * 3 * k;
+    final int half = nomCap / 2;
+    final FloatBuffer fbuf = c1.getBuffer();
+
+    for (int i = 0; i < nomCap; i++) {
+      fbuf.append(i - half); // range: -half to half-1
+    }
+    final byte[] c1ser = c1.toByteArray();
+    final PositionalSegment posSeg = PositionalSegment.wrap(MemorySegment.ofArray(c1ser));
+    final Compactor compactor = ReqSerDe.extractCompactor(posSeg, fbuf.isSorted(), hra);
+    assertEquals(compactor.minItem, (float) -half);
+    assertEquals(compactor.maxItem, (float) (half - 1));
+  }
 }

--- a/src/test/java/org/apache/datasketches/req/ReqCompactorTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqCompactorTest.java
@@ -144,4 +144,26 @@ public class ReqCompactorTest {
     assertEquals(compactor.minItem, (float) -half);
     assertEquals(compactor.maxItem, (float) (half - 1));
   }
+
+  @Test
+  public void checkSerDeWithInfiniteValues() {
+    checkSerDeInfiniteImpl(12, false);
+    checkSerDeInfiniteImpl(12, true);
+  }
+
+  private static void checkSerDeInfiniteImpl(final int k, final boolean hra) {
+    final ReqCompactor c1 = new ReqCompactor((byte)0, hra, k, null);
+    final FloatBuffer fbuf = c1.getBuffer();
+
+    fbuf.append(Float.POSITIVE_INFINITY);
+    fbuf.append(1);
+    fbuf.append(Float.NEGATIVE_INFINITY);
+    fbuf.append(-1);
+
+    final byte[] c1ser = c1.toByteArray();
+    final PositionalSegment posSeg = PositionalSegment.wrap(MemorySegment.ofArray(c1ser));
+    final Compactor compactor = ReqSerDe.extractCompactor(posSeg, fbuf.isSorted(), hra);
+    assertEquals(compactor.minItem, Float.NEGATIVE_INFINITY);
+    assertEquals(compactor.maxItem, Float.POSITIVE_INFINITY);
+  }
 }

--- a/src/test/java/org/apache/datasketches/req/ReqSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchCrossLanguageTest.java
@@ -51,6 +51,30 @@ public class ReqSketchCrossLanguageTest {
     }
   }
 
+  @Test(groups = {GENERATE_JAVA_FILES})
+  public void generateNegativeBinariesForCompatibilityTesting() throws IOException {
+    final int[] nArr = {1, 10};
+    for (final int n: nArr) {
+      final ReqSketch sk = ReqSketch.builder().build();
+      for (int i = 1; i <= n; i++) {
+        sk.update(-i);
+      }
+      putBytesToJavaPath("req_float_negative_n" + n + "_java.sk", sk.toByteArray());
+    }
+  }
+
+  @Test(groups = {GENERATE_JAVA_FILES})
+  public void generateMixedBinariesForCompatibilityTesting() throws IOException {
+    final int[] nArr = {1, 10};
+    for (final int n: nArr) {
+      final ReqSketch sk = ReqSketch.builder().build();
+      for (int i = -n; i <= n; i++) {
+        sk.update(i);
+      }
+      putBytesToJavaPath("req_float_mixed_n" + n + "_java.sk", sk.toByteArray());
+    }
+  }
+
   @Test(groups = {CHECK_CPP_FILES})
   public void deserializeFromCpp() throws IOException {
     final int[] nArr = {0, 1, 10, 100, 1000, 10000, 100000, 1000000};

--- a/src/test/java/org/apache/datasketches/req/ReqSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchCrossLanguageTest.java
@@ -98,48 +98,4 @@ public class ReqSketchCrossLanguageTest {
       }
     }
   }
-
-  @Test(groups = {CHECK_CPP_FILES})
-  public void deserializeNegativeFromCpp() throws IOException {
-    final int[] nArr = {1, 10};
-    for (final int n: nArr) {
-      final byte[] bytes = getFileBytes(cppPath, "req_float_negative_n" + n + "_cpp.sk");
-      final ReqSketch sk = ReqSketch.heapify(MemorySegment.ofArray(bytes));
-      assertTrue(!sk.isEmpty());
-      assertEquals(sk.getN(), n);
-      assertEquals(sk.getMinItem(), -n);
-      assertEquals(sk.getMaxItem(), -1);
-      final QuantilesFloatsSketchIterator it = sk.iterator();
-      long weight = 0;
-      while(it.next()) {
-        assertTrue(it.getQuantile() >= sk.getMinItem());
-        assertTrue(it.getQuantile() <= sk.getMaxItem());
-        weight += it.getWeight();
-      }
-      assertEquals(weight, n);
-    }
-  }
-
-  @Test(groups = {CHECK_CPP_FILES})
-  public void deserializeMixedFromCpp() throws IOException {
-    final int[] nArr = {1, 10};
-    for (final int n: nArr) {
-      final byte[] bytes = getFileBytes(cppPath, "req_float_mixed_n" + n + "_cpp.sk");
-      final ReqSketch sk = ReqSketch.heapify(MemorySegment.ofArray(bytes));
-      assertTrue(!sk.isEmpty());
-      final int expectedN = 2 * n + 1; // range -n to n inclusive
-      assertEquals(sk.getN(), expectedN);
-      assertEquals(sk.getMinItem(), -n);
-      assertEquals(sk.getMaxItem(), (float) n);
-      final QuantilesFloatsSketchIterator it = sk.iterator();
-      long weight = 0;
-      while(it.next()) {
-        assertTrue(it.getQuantile() >= sk.getMinItem());
-        assertTrue(it.getQuantile() <= sk.getMaxItem());
-        weight += it.getWeight();
-      }
-      assertEquals(weight, expectedN);
-    }
-  }
-
 }

--- a/src/test/java/org/apache/datasketches/req/ReqSketchCrossLanguageTest.java
+++ b/src/test/java/org/apache/datasketches/req/ReqSketchCrossLanguageTest.java
@@ -99,4 +99,47 @@ public class ReqSketchCrossLanguageTest {
     }
   }
 
+  @Test(groups = {CHECK_CPP_FILES})
+  public void deserializeNegativeFromCpp() throws IOException {
+    final int[] nArr = {1, 10};
+    for (final int n: nArr) {
+      final byte[] bytes = getFileBytes(cppPath, "req_float_negative_n" + n + "_cpp.sk");
+      final ReqSketch sk = ReqSketch.heapify(MemorySegment.ofArray(bytes));
+      assertTrue(!sk.isEmpty());
+      assertEquals(sk.getN(), n);
+      assertEquals(sk.getMinItem(), -n);
+      assertEquals(sk.getMaxItem(), -1);
+      final QuantilesFloatsSketchIterator it = sk.iterator();
+      long weight = 0;
+      while(it.next()) {
+        assertTrue(it.getQuantile() >= sk.getMinItem());
+        assertTrue(it.getQuantile() <= sk.getMaxItem());
+        weight += it.getWeight();
+      }
+      assertEquals(weight, n);
+    }
+  }
+
+  @Test(groups = {CHECK_CPP_FILES})
+  public void deserializeMixedFromCpp() throws IOException {
+    final int[] nArr = {1, 10};
+    for (final int n: nArr) {
+      final byte[] bytes = getFileBytes(cppPath, "req_float_mixed_n" + n + "_cpp.sk");
+      final ReqSketch sk = ReqSketch.heapify(MemorySegment.ofArray(bytes));
+      assertTrue(!sk.isEmpty());
+      final int expectedN = 2 * n + 1; // range -n to n inclusive
+      assertEquals(sk.getN(), expectedN);
+      assertEquals(sk.getMinItem(), -n);
+      assertEquals(sk.getMaxItem(), (float) n);
+      final QuantilesFloatsSketchIterator it = sk.iterator();
+      long weight = 0;
+      while(it.next()) {
+        assertTrue(it.getQuantile() >= sk.getMinItem());
+        assertTrue(it.getQuantile() <= sk.getMaxItem());
+        weight += it.getWeight();
+      }
+      assertEquals(weight, expectedN);
+    }
+  }
+
 }


### PR DESCRIPTION
`Float.MIN_VALUE` is smallest positive value. So if REQ sketch include negative values, min value is not respected after deserialization.

C++ is ok, because it delegates to comparator not like java.

After this PR merged, I will send PR for compat in C++.