### PR TITLE
Add HllUnion.update(HllUnion)

### DIFF
--- a/src/main/java/org/apache/datasketches/hll/HllUnion.java
+++ b/src/main/java/org/apache/datasketches/hll/HllUnion.java
@@ -176,7 +176,7 @@ public class HllUnion extends BaseHllSketch {
     checkRebuildCurMinNumKxQ(gadget);
     return gadget.getEstimate();
   }
-
+  
   /**
    * Gets the effective <i>lgConfigK</i> for the HllUnion operator, which may be less than
    * <i>lgMaxK</i>.
@@ -320,6 +320,14 @@ public class HllUnion extends BaseHllSketch {
     gadget.hllSketchImpl = unionImpl(sketch, gadget, lgMaxK);
   }
 
+  /**
+   * Update this HllUnion operator with the given HllUnion.
+   * @param union the given HllUnion.
+   */
+  public void update(final HllUnion union) {
+    gadget.hllSketchImpl = unionImpl(union.gadget, gadget, lgMaxK);
+  }
+  
   @Override
   void couponUpdate(final int coupon) {
     if (coupon == EMPTY) { return; }

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -31,8 +31,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.foreign.MemorySegment;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.VarHandle;
+//import java.lang.invoke.MethodHandles;
+//import java.lang.invoke.VarHandle;
 
 import org.apache.datasketches.common.SketchesStateException;
 import org.testng.annotations.Test;
@@ -42,22 +42,14 @@ import org.testng.annotations.Test;
  */
 public class UnionCaseTest {
   private static final String LS = System.getProperty("line.separator");
-  private static final VarHandle GADGET_HANDLE;
   long v = 0;
   final static int maxLgK = 12;
-  HllSketch source;
-  //HllUnion union;
+  HllSketch skSource;
+  HllUnion uSource;
   String hfmt = "%10s%10s%10s%10s%10s%10s%10s%10s%10s%10s%10s" + LS;
   String hdr = String.format(hfmt, "caseNum","srcLgKStr","gdtLgKStr","srcType","gdtType",
       "srcSeg","gdtSeg","srcMode","gdtMode","srcOoof","gdtOoof");
 
-  static {
-    try {
-      MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(HllUnion.class, MethodHandles.lookup());
-      GADGET_HANDLE = lookup.findVarHandle(HllUnion.class, "gadget", HllSketch.class);
-    } catch (Exception e) { throw new RuntimeException(e); }
-  }
-  
   @Test
   public void checkAllCases() {
     print(hdr);
@@ -80,7 +72,7 @@ public class UnionCaseTest {
 
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_8, false, true);
+      checkCase(i, HLL_8, false, true); //srcUnion
     }
     println("");
     
@@ -104,18 +96,26 @@ public class UnionCaseTest {
     
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_8, true, true);
+      checkCase(i, HLL_8, true, true); //srcUnion
     }
     println("");
   }
 
   private void checkCase(final int caseNum, final TgtHllType srcType, final boolean srcSeg, final boolean srcUnion) {
-    source = getSource(caseNum, srcType, srcSeg, srcUnion);
+    if (srcUnion) {
+      uSource = getUnionSrc(caseNum);
+    } else {
+      skSource = getSkSource(caseNum, srcType, srcSeg);
+    }
     final boolean gdtSeg = (caseNum & 1) > 0;
     final HllUnion union = getUnion(caseNum, gdtSeg);
-    union.update(source);
+    if (srcUnion) {
+      union.update(uSource);
+    } else {
+      union.update(skSource);
+    }
     final int totalU = getSrcCount(caseNum, maxLgK) + getUnionCount(caseNum);
-    output(caseNum, source, union, totalU);
+    output(caseNum, skSource, union, totalU);
   }
 
   private void output(final int caseNum, final HllSketch source, final HllUnion union, final int totalU) {
@@ -143,22 +143,25 @@ public class UnionCaseTest {
     assertTrue(err < rse, "Err: " + err + ", RSE: " + rse);
   }
 
-  private HllSketch getSource(final int caseNum, final TgtHllType tgtHllType, final boolean useMemorySegment,
-      final boolean useHllUnion) {
+  private HllSketch getSkSource(final int caseNum, final TgtHllType tgtHllType, final boolean useMemorySegment) {
     final int srcLgK = getSrcLgK(caseNum, maxLgK);
     final int srcU = getSrcCount(caseNum, maxLgK);
     if (useMemorySegment) {
       return buildMemorySegmentSketch(srcLgK, tgtHllType, srcU);
-    } else if (useHllUnion) {
-      final HllSketch sk = buildHeapSketch(srcLgK, tgtHllType, srcU);
-      final HllUnion u = new HllUnion(maxLgK);
-      u.update(sk);
-      return (HllSketch) GADGET_HANDLE.get(u);
     } else {
       return buildHeapSketch(srcLgK, tgtHllType, srcU);
     }
   }
 
+  private HllUnion getUnionSrc(final int caseNum) {
+    final int srcLgK = getSrcLgK(caseNum, maxLgK);
+    final int srcU = getSrcCount(caseNum, maxLgK);
+    final HllSketch sk = buildHeapSketch(srcLgK, HLL_8, srcU);
+    final HllUnion u = new HllUnion(maxLgK);
+    u.update(sk);
+    return u;
+  }
+  
   private HllUnion getUnion(final int caseNum, final boolean useMemorySegment) {
     final int unionU = getUnionCount(caseNum);
     return (useMemorySegment) ? buildMemorySegmentUnion(maxLgK, unionU) : buildHeapUnion(maxLgK, unionU);

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -31,6 +31,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.foreign.MemorySegment;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 
 import org.apache.datasketches.common.SketchesStateException;
 import org.testng.annotations.Test;
@@ -40,6 +42,7 @@ import org.testng.annotations.Test;
  */
 public class UnionCaseTest {
   private static final String LS = System.getProperty("line.separator");
+  private static final VarHandle GADGET_HANDLE;
   long v = 0;
   final static int maxLgK = 12;
   HllSketch source;
@@ -48,47 +51,66 @@ public class UnionCaseTest {
   String hdr = String.format(hfmt, "caseNum","srcLgKStr","gdtLgKStr","srcType","gdtType",
       "srcSeg","gdtSeg","srcMode","gdtMode","srcOoof","gdtOoof");
 
+  static {
+    try {
+      MethodHandles.Lookup lookup = MethodHandles.privateLookupIn(HllUnion.class, MethodHandles.lookup());
+      GADGET_HANDLE = lookup.findVarHandle(HllUnion.class, "gadget", HllSketch.class);
+    } catch (Exception e) { throw new RuntimeException(e); }
+  }
+  
   @Test
   public void checkAllCases() {
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_4, false);
+      checkCase(i, HLL_4, false, false);
     }
     println("");
 
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_6, false);
+      checkCase(i, HLL_6, false, false);
     }
     println("");
 
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_8, false);
+      checkCase(i, HLL_8, false, false);
     }
     println("");
 
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_4, true);
+      checkCase(i, HLL_8, false, true);
+    }
+    println("");
+    
+    print(hdr);
+    for (int i = 0; i < 24; i++) {
+      checkCase(i, HLL_4, true, false);
     }
     println("");
 
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_6, true);
+      checkCase(i, HLL_6, true, false);
     }
     println("");
 
     print(hdr);
     for (int i = 0; i < 24; i++) {
-      checkCase(i, HLL_8, true);
+      checkCase(i, HLL_8, true, false);
+    }
+    println("");
+    
+    print(hdr);
+    for (int i = 0; i < 24; i++) {
+      checkCase(i, HLL_8, true, true);
     }
     println("");
   }
 
-  private void checkCase(final int caseNum, final TgtHllType srcType, final boolean srcSeg) {
-    source = getSource(caseNum, srcType, srcSeg);
+  private void checkCase(final int caseNum, final TgtHllType srcType, final boolean srcSeg, final boolean srcUnion) {
+    source = getSource(caseNum, srcType, srcSeg, srcUnion);
     final boolean gdtSeg = (caseNum & 1) > 0;
     final HllUnion union = getUnion(caseNum, gdtSeg);
     union.update(source);
@@ -121,11 +143,17 @@ public class UnionCaseTest {
     assertTrue(err < rse, "Err: " + err + ", RSE: " + rse);
   }
 
-  private HllSketch getSource(final int caseNum, final TgtHllType tgtHllType, final boolean useMemorySegment) {
+  private HllSketch getSource(final int caseNum, final TgtHllType tgtHllType, final boolean useMemorySegment,
+      final boolean useHllUnion) {
     final int srcLgK = getSrcLgK(caseNum, maxLgK);
     final int srcU = getSrcCount(caseNum, maxLgK);
     if (useMemorySegment) {
       return buildMemorySegmentSketch(srcLgK, tgtHllType, srcU);
+    } else if (useHllUnion) {
+      final HllSketch sk = buildHeapSketch(srcLgK, tgtHllType, srcU);
+      final HllUnion u = new HllUnion(maxLgK);
+      u.update(sk);
+      return (HllSketch) GADGET_HANDLE.get(u);
     } else {
       return buildHeapSketch(srcLgK, tgtHllType, srcU);
     }
@@ -133,7 +161,7 @@ public class UnionCaseTest {
 
   private HllUnion getUnion(final int caseNum, final boolean useMemorySegment) {
     final int unionU = getUnionCount(caseNum);
-    return (useMemorySegment) ? buildMemorSegmentUnion(maxLgK, unionU) : buildHeapUnion(maxLgK, unionU);
+    return (useMemorySegment) ? buildMemorySegmentUnion(maxLgK, unionU) : buildHeapUnion(maxLgK, unionU);
   }
 
   private static int getUnionCount(final int caseNum) {
@@ -394,7 +422,7 @@ public class UnionCaseTest {
     return u;
   }
 
-  private HllUnion buildMemorSegmentUnion(final int lgMaxK, final int n) {
+  private HllUnion buildMemorySegmentUnion(final int lgMaxK, final int n) {
     final int bytes = HllSketch.getMaxUpdatableSerializationBytes(lgMaxK, TgtHllType.HLL_8);
     final MemorySegment wseg = MemorySegment.ofArray(new byte[bytes]);
     final HllUnion u = new HllUnion(lgMaxK, wseg);
@@ -436,7 +464,7 @@ public class UnionCaseTest {
    * @param o value to print
    */
   static void print(final Object o) {
-    //System.out.print(o.toString()); //disable here
+    System.out.print(o.toString()); //disable here
   }
 
   /**
@@ -444,7 +472,7 @@ public class UnionCaseTest {
    * @param args arguments
    */
   static void printf(final String fmt, final Object...args) {
-    //System.out.printf(fmt, args); //disable here
+    System.out.printf(fmt, args); //disable here
   }
 
 }

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -464,7 +464,7 @@ public class UnionCaseTest {
    * @param o value to print
    */
   static void print(final Object o) {
-    System.out.print(o.toString()); //disable here
+    //System.out.print(o.toString()); //disable here
   }
 
   /**
@@ -472,7 +472,7 @@ public class UnionCaseTest {
    * @param args arguments
    */
   static void printf(final String fmt, final Object...args) {
-    System.out.printf(fmt, args); //disable here
+    //System.out.printf(fmt, args); //disable here
   }
 
 }

--- a/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
+++ b/src/test/java/org/apache/datasketches/hll/UnionCaseTest.java
@@ -31,8 +31,6 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import java.lang.foreign.MemorySegment;
-//import java.lang.invoke.MethodHandles;
-//import java.lang.invoke.VarHandle;
 
 import org.apache.datasketches.common.SketchesStateException;
 import org.testng.annotations.Test;
@@ -108,14 +106,18 @@ public class UnionCaseTest {
       skSource = getSkSource(caseNum, srcType, srcSeg);
     }
     final boolean gdtSeg = (caseNum & 1) > 0;
-    final HllUnion union = getUnion(caseNum, gdtSeg);
+    final HllUnion union = getUnion(caseNum, gdtSeg); //union under test
+    HllSketch refSketch;
     if (srcUnion) {
       union.update(uSource);
+      refSketch = union.getResult(HLL_8);
     } else {
       union.update(skSource);
+      refSketch = skSource;
     }
     final int totalU = getSrcCount(caseNum, maxLgK) + getUnionCount(caseNum);
-    output(caseNum, skSource, union, totalU);
+    
+    output(caseNum, refSketch, union, totalU);
   }
 
   private void output(final int caseNum, final HllSketch source, final HllUnion union, final int totalU) {


### PR DESCRIPTION
This adds the ability of the HllUnion operator to update from HllUnions directly, bypassing an expensive copy.

Corrects some spelling errors.