### PR TITLE
Fix typo on javadoc.yml

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -66,4 +66,3 @@ jobs:
           name: versioned-javadocs-${{ env.POM_VERSION }}
           path: javadoc-staging/
           retention-days: 30
-s


### PR DESCRIPTION
Somehow a single s appeared on the last line, invalidating the entire workflow.