### PR TITLE
Update workflow cpp-serde-compat-yml

### DIFF
--- a/.github/workflows/cpp-serde-compat.yml
+++ b/.github/workflows/cpp-serde-compat.yml
@@ -51,6 +51,6 @@ jobs:
       - name: Upload C++ Generated Sketch Files
         uses: actions/upload-artifact@v4
         with:
-          name: cpp-generated-sketch-files
+          name: cpp_generated_files
           path: serialization_test_data/cpp_generated_files/
           retention-days: 30

--- a/.github/workflows/cpp-serde-compat.yml
+++ b/.github/workflows/cpp-serde-compat.yml
@@ -47,3 +47,10 @@ jobs:
 
       - name: Run Java tests
         run: mvn test -P check-cpp-files
+
+      - name: Upload C++ Generated Sketch Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: cpp-generated-sketch-files
+          path: serialization_test_data/cpp_generated_files/
+          retention-days: 30

--- a/.github/workflows/cpp-serde-compat.yml
+++ b/.github/workflows/cpp-serde-compat.yml
@@ -49,7 +49,7 @@ jobs:
         run: mvn test -P check-cpp-files
 
       - name: Upload C++ Generated Sketch Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cpp_generated_files
           path: serialization_test_data/cpp_generated_files/


### PR DESCRIPTION
This Java GHA CI workflow (in brief):
- Checks out C++, builds it and runs all the tests
- Some of those tests generate sketch image files of the form ‘*.sk’. 
- Copies just those *.sk files into a directory ‘serialization_test_data/cpp_generated_files’ where Java can read them.
- Sets up Java to run tests using the java profile ‘check-cpp-files’

This all works ok, but I have modified this workflow to provide a downloadable Artifact at the end whereby the user can download the directory that contains all the CPP generated sketch images.  It is very useful to have an up-to-date copy of these CPP generated files for local testing purposes.  The Artifact will be deleted after 30 days.